### PR TITLE
Fix physics use-after-free crash for offscreen display objects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   WORKSPACE: ${{ github.workspace }}
-  DEVELOPER_DIR: /Applications/Xcode_26.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
   BUILD_NUMBER: ${{ github.event.inputs.buildNumber }}
   YEAR: ${{ github.event.inputs.buildYear }}
 
@@ -68,8 +68,7 @@ jobs:
         runner:
           - macos-26
         xcode:
-          - Xcode_26.0
-          - Xcode_26.1
+          - Xcode_26.2
         target:
           - template
           - template-angle
@@ -113,7 +112,6 @@ jobs:
           - macos-15
         xcode:
           - Xcode_16.4
-          - Xcode_16.3
         target:
           - template
           - template-angle
@@ -475,7 +473,7 @@ jobs:
       - source-code
     runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Set up emsdk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   WORKSPACE: ${{ github.workspace }}
-  DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
   BUILD_NUMBER: ${{ github.event.inputs.buildNumber }}
   YEAR: ${{ github.event.inputs.buildYear }}
 
@@ -68,7 +68,7 @@ jobs:
         runner:
           - macos-26
         xcode:
-          - Xcode_26.2
+          - Xcode_26.3
         target:
           - template
           - template-angle
@@ -473,7 +473,7 @@ jobs:
       - source-code
     runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     steps:
       - run: CDR="$(basename "$(pwd)")" ; cd .. ; rm -rf "$CDR" ; mkdir -p "$CDR" ; cd "$CDR"
       - name: Set up emsdk

--- a/bin/mac/build_dmg.sh
+++ b/bin/mac/build_dmg.sh
@@ -247,14 +247,15 @@ ICON_Y=$APP_Y
 rm -f "$DMG_FILE"
 
 # If we have a build number and ImageMagick's convert command is available, brand the DMG background
-if [ "$FULL_BUILD_NUM" != "" ] && [ -x "$(which convert)" ]
+if [ "$FULL_BUILD_NUM" != "" ] && [ -x "$(which magick)" ]
 then
+	FONT=/System/Library/Fonts/Monaco.ttf
 	TMPBACKGROUND=/tmp/CoronaBackground$$.png
-	convert sdk/dmg/CoronaBackground.png -pointsize 13 -stroke DarkGrey -fill DarkGrey -draw "text 39,387 '$FULL_BUILD_NUM'" "$TMPBACKGROUND"
+	magick sdk/dmg/CoronaBackground.png -pointsize 13 -stroke DarkGrey -fill DarkGrey -font "$FONT" -draw "text 39,387 '$FULL_BUILD_NUM'" "$TMPBACKGROUND"
 	BACKGROUND_PATH="$TMPBACKGROUND"
 
-	convert sdk/dmg/BG.png    -pointsize 13 -stroke DarkGrey -fill DarkGrey -draw "text 39,387 '$FULL_BUILD_NUM'" sdk/dmg/bgp.png
-	convert sdk/dmg/BG@2x.png -pointsize 26 -stroke DarkGrey -fill DarkGrey -draw "text 78,774 '$FULL_BUILD_NUM'" sdk/dmg/bgp@2x.png
+	magick sdk/dmg/BG.png    -pointsize 13 -stroke DarkGrey -fill DarkGrey -font "$FONT" -draw "text 39,387 '$FULL_BUILD_NUM'" sdk/dmg/bgp.png
+	magick sdk/dmg/BG@2x.png -pointsize 26 -stroke DarkGrey -fill DarkGrey -font "$FONT" -draw "text 78,774 '$FULL_BUILD_NUM'" sdk/dmg/bgp@2x.png
 else
 	cp sdk/dmg/BG.png    sdk/dmg/bgp.png
 	cp sdk/dmg/BG@2x.png sdk/dmg/bgp@2x.png

--- a/librtt/Display/Rtt_ShaderResource.cpp
+++ b/librtt/Display/Rtt_ShaderResource.cpp
@@ -166,7 +166,7 @@ void
 TimeTransform::SetDefault()
 {
     func = &PingPong;
-    arg1 = Display::GetGpuSupportsHighPrecisionFragmentShaders() ? 3600 * 5 : 50;
+    arg1 = 50; // 50 should be safe for mediump
     arg2 = arg3 = 0;
 }
 

--- a/librtt/Renderer/Rtt_Renderer.cpp
+++ b/librtt/Renderer/Rtt_Renderer.cpp
@@ -235,7 +235,6 @@ Renderer::BeginFrame( Real totalTime, Real deltaTime, const TimeTransform *defTi
     fPrevious = RenderData();
     fVertexOffset = 0;
     fVertexCount = 0;
-    fVertexExtra = 0;
     fIndexOffset = 0;
     fIndexCount = 0;
     fRenderDataCount = 0;
@@ -607,6 +606,7 @@ Renderer::Insert( const RenderData* data, const ShaderData * shaderData )
 
     // Geometry that is stored on the GPU does not need to be copied
     // over each frame. As a consequence, they can not be batched.
+    U32 previousVerticesUsed = 0;
     if( geometry->GetStoredOnGPU() && !fWireframeEnabled )
     {
         FlushBatch();
@@ -631,9 +631,6 @@ Renderer::Insert( const RenderData* data, const ShaderData * shaderData )
 
         fCachedVertexOffset = fVertexOffset;
         fCachedVertexCount = fVertexCount;
-        fCachedVertexExtra = fVertexExtra;
-        fOffsetCorrection = 0;
-        fVertexExtra = 0;
         fVertexOffset = 0;
         fVertexCount = geometry->GetVerticesUsed();
         fIndexCount = geometry->GetIndicesUsed();
@@ -714,11 +711,9 @@ Renderer::Insert( const RenderData* data, const ShaderData * shaderData )
 			}
         }
         
-        fVertexExtra = vertexExtra;
-
         // Copy the the incoming vertex data into the current Geometry
         // pool instance, even if the data will not be batched.
-        CopyVertexData( geometry, fCurrentVertex, batch && enoughSpace );
+        CopyVertexData( geometry, fCurrentVertex, vertexExtra );
 
         if (isInstanced)
         {
@@ -728,6 +723,9 @@ Renderer::Insert( const RenderData* data, const ShaderData * shaderData )
             
             mustReconcileFormats = true; // pointers out of date
         }
+
+		// The format might change, so remember where the old one would end.
+		previousVerticesUsed = fCurrentGeometry->GetVerticesUsed();
 
         fCurrentVertex += verticesRequired;
         fVertexCount += verticesComputed;
@@ -948,12 +946,9 @@ Renderer::Insert( const RenderData* data, const ShaderData * shaderData )
 
     if (mustReconcileFormats)
     {
-		if ( !geometry->GetStoredOnGPU() )
-		{
-			fOffsetCorrection = fVertexOffset;
-		}
-		
-        FormatExtensionList::ReconcileFormats( fAllocator, fBackCommandBuffer, programList, extensionList, fVertexOffset );
+        FormatExtensionList::ReconcileFormats( fAllocator, fBackCommandBuffer, programList, extensionList, previousVerticesUsed );
+        
+        fVertexOffset = 0; // off-GPU offset rebased to end of previous vertices
     }
     
     if (dirtyIndices.Length() > 0)
@@ -1569,7 +1564,7 @@ Renderer::CheckAndInsertDrawCommand()
         }
         else
         {
-            fBackCommandBuffer->Draw( fVertexOffset - fOffsetCorrection, fVertexCount - fDegenerateVertexCount, fPreviousPrimitiveType );
+            fBackCommandBuffer->Draw( fVertexOffset, fVertexCount - fDegenerateVertexCount, fPreviousPrimitiveType );
         }
         INCREMENT( fStatistics.fDrawCallCount );
 
@@ -1794,12 +1789,11 @@ void
 Renderer::UpdateBatch( bool batch, bool enoughSpace, bool storedOnGPU, U32 verticesRequired )
 {
     CheckAndInsertDrawCommand();
-    
+     
     if( storedOnGPU && !fWireframeEnabled )
     {
         fVertexOffset = fCachedVertexOffset;
         fVertexCount = fCachedVertexCount;
-        fVertexExtra = fCachedVertexExtra;
 
         if( enoughSpace )
         {
@@ -1807,7 +1801,7 @@ Renderer::UpdateBatch( bool batch, bool enoughSpace, bool storedOnGPU, U32 verti
         }
     }
     
-    fVertexOffset += fVertexCount * (1 + fVertexExtra);
+    fVertexOffset += fVertexCount;
     fVertexCount = 0;
     fIndexCount = 0;
 
@@ -1827,14 +1821,14 @@ Renderer::UpdateBatch( bool batch, bool enoughSpace, bool storedOnGPU, U32 verti
 }
 
 void
-Renderer::CopyVertexData( Geometry* geometry, Geometry::Vertex* destination, bool interior )
+Renderer::CopyVertexData( Geometry* geometry, Geometry::Vertex* destination, int extraCount )
 {
     const U32 verticesUsed = geometry->GetVerticesUsed();
     const U32 vertexSize = sizeof(Geometry::Vertex);
 
-    if (0 != fVertexExtra)
+    if (0 != extraCount)
     {
-        CopyExtendedVertexData( geometry, destination, interior );
+        CopyExtendedVertexData( geometry, destination, extraCount );
     }
     
     else if( fWireframeEnabled )
@@ -2083,7 +2077,7 @@ Renderer::MergeVertexDataRange( Geometry::Vertex** destination, Geometry* geomet
 }
 
 void
-Renderer::CopyExtendedVertexData( Geometry* geometry, Geometry::Vertex* destination, bool interior )
+Renderer::CopyExtendedVertexData( Geometry* geometry, Geometry::Vertex* destination, int extraCount )
 {
     const U32 verticesUsed = geometry->GetVerticesUsed();
 
@@ -2093,22 +2087,22 @@ Renderer::CopyExtendedVertexData( Geometry* geometry, Geometry::Vertex* destinat
         switch( geometry->GetPrimitiveType() )
         {
             case Geometry::kTriangleStrip:
-                CopyExtendedTriangleStripsAsLines( geometry, destination );
+                CopyExtendedTriangleStripsAsLines( geometry, destination, extraCount );
                 break;
             case Geometry::kTriangleFan:
-                CopyExtendedTriangleFanAsLines( geometry, destination );
+                CopyExtendedTriangleFanAsLines( geometry, destination, extraCount );
                 break;
             case Geometry::kTriangles:
-                CopyExtendedTrianglesAsLines( geometry, destination );
+                CopyExtendedTrianglesAsLines( geometry, destination, extraCount );
                 break;
             case Geometry::kIndexedTriangles:
-                CopyExtendedIndexedTrianglesAsLines( geometry, destination );
+                CopyExtendedIndexedTrianglesAsLines( geometry, destination, extraCount );
                 break;
             case Geometry::kLineLoop:
-                MergeVertexDataRange( &destination, geometry, verticesUsed, fVertexExtra );
+                MergeVertexDataRange( &destination, geometry, verticesUsed, extraCount );
                 break;
             case Geometry::kLines:
-                MergeVertexDataRange( &destination, geometry, verticesUsed, fVertexExtra );
+                MergeVertexDataRange( &destination, geometry, verticesUsed, extraCount );
                 break;
         }
     }
@@ -2118,11 +2112,11 @@ Renderer::CopyExtendedVertexData( Geometry* geometry, Geometry::Vertex* destinat
         {
             // Triangle strips are batched by adding degenerate triangles
             // at the beginning and end of each strip.
-            MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), 0, fVertexExtra );
+            MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), 0, extraCount );
 
-            MergeVertexDataRange( &destination, geometry, verticesUsed, fVertexExtra );
+            MergeVertexDataRange( &destination, geometry, verticesUsed, extraCount );
 
-            MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), verticesUsed - 1, fVertexExtra );
+            MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), verticesUsed - 1, extraCount );
 
             fDegenerateVertexCount = 1;
         }
@@ -2130,13 +2124,13 @@ Renderer::CopyExtendedVertexData( Geometry* geometry, Geometry::Vertex* destinat
         {
             // For data which does not exist on the GPU and is not batched,
             // we still double buffer it to be threadsafe.
-            MergeVertexDataRange( &destination, geometry, verticesUsed, fVertexExtra );
+            MergeVertexDataRange( &destination, geometry, verticesUsed, extraCount );
         }
     }
 }
 
 void
-Renderer::CopyExtendedTriangleStripsAsLines( Geometry* geometry, Geometry::Vertex* destination )
+Renderer::CopyExtendedTriangleStripsAsLines( Geometry* geometry, Geometry::Vertex* destination, int extraCount )
 {
     const U32 count = geometry->GetVerticesUsed() - 2;
     const Geometry::Vertex* data = geometry->GetVertexData();
@@ -2144,18 +2138,18 @@ Renderer::CopyExtendedTriangleStripsAsLines( Geometry* geometry, Geometry::Verte
     for( U32 i = 0; i < count; ++i )
     {
         // Line 1
-        MergeVertexDataRange( &destination, geometry, 2, fVertexExtra );
+        MergeVertexDataRange( &destination, geometry, 2, extraCount );
         
         // Line 2
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), i, fVertexExtra );
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), i + 2, fVertexExtra );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), i, extraCount );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), i + 2, extraCount );
     }
     
-    MergeVertexDataRange( &destination, geometry, 2, fVertexExtra, count );
+    MergeVertexDataRange( &destination, geometry, 2, extraCount, count );
 }
 
 void
-Renderer::CopyExtendedTriangleFanAsLines( Geometry* geometry, Geometry::Vertex* destination )
+Renderer::CopyExtendedTriangleFanAsLines( Geometry* geometry, Geometry::Vertex* destination, int extraCount )
 {
     const U32 count = geometry->GetVerticesUsed() - 1;
     const Geometry::Vertex* data = geometry->GetVertexData();
@@ -2163,20 +2157,20 @@ Renderer::CopyExtendedTriangleFanAsLines( Geometry* geometry, Geometry::Vertex* 
     for( U32 i = 1; i < count; ++i )
     {
         // Line 1
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), 0, fVertexExtra );
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), i, fVertexExtra );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), 0, extraCount );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), i, extraCount );
         
         // Line 2
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), i, fVertexExtra );
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), i + 1, fVertexExtra );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), i, extraCount );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), i + 1, extraCount );
     }
     
-    MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), 0, fVertexExtra );
-    MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), count, fVertexExtra );
+    MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), 0, extraCount );
+    MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), count, extraCount );
 }
 
 void
-Renderer::CopyExtendedTrianglesAsLines( Geometry* geometry, Geometry::Vertex* destination )
+Renderer::CopyExtendedTrianglesAsLines( Geometry* geometry, Geometry::Vertex* destination, int extraCount )
 {
     const U32 triangleCount = geometry->GetVerticesUsed() / 3;
     const Geometry::Vertex* data = geometry->GetVertexData();
@@ -2186,19 +2180,19 @@ Renderer::CopyExtendedTrianglesAsLines( Geometry* geometry, Geometry::Vertex* de
         U32 index = i * 3;
 
         // Line 1
-        MergeVertexDataRange( &destination, geometry, 2, fVertexExtra, index );
+        MergeVertexDataRange( &destination, geometry, 2, extraCount, index );
         
         // Line 2
-        MergeVertexDataRange( &destination, geometry, 2, fVertexExtra, index + 1 );
+        MergeVertexDataRange( &destination, geometry, 2, extraCount, index + 1 );
 
         // Line 3
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), index + 2, fVertexExtra );
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), index, fVertexExtra );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), index + 2, extraCount );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), index, extraCount );
     }
 }
 
 void
-Renderer::CopyExtendedIndexedTrianglesAsLines( Geometry* geometry, Geometry::Vertex* destination )
+Renderer::CopyExtendedIndexedTrianglesAsLines( Geometry* geometry, Geometry::Vertex* destination, int extraCount )
 {
     const Geometry::Vertex* vertexData = geometry->GetVertexData();
     const Geometry::Index* indexData = geometry->GetIndexData();
@@ -2209,16 +2203,16 @@ Renderer::CopyExtendedIndexedTrianglesAsLines( Geometry* geometry, Geometry::Ver
         U32 index = i * 3;
         
         // Line 1
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index], fVertexExtra );
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index + 1], fVertexExtra );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index], extraCount );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index + 1], extraCount );
                 
         // Line 2
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index + 1], fVertexExtra );
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index + 2], fVertexExtra );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index + 1], extraCount );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index + 2], extraCount );
 
         // Line 3
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index + 2], fVertexExtra );
-        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index], fVertexExtra );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index + 2], extraCount );
+        MergeVertexData( &destination, geometry->GetVertexData(), geometry->GetExtendedVertexData(), indexData[index], extraCount );
     }
 }
 

--- a/librtt/Renderer/Rtt_Renderer.h
+++ b/librtt/Renderer/Rtt_Renderer.h
@@ -298,7 +298,7 @@ class Renderer
     
     protected:
         void UpdateBatch( bool batch, bool enoughSpace, bool storedOnGPU, U32 verticesRequired );
-        void CopyVertexData( Geometry* geometry, Geometry::Vertex* destination, bool interior );
+        void CopyVertexData( Geometry* geometry, Geometry::Vertex* destination, int extraCount );
         void CopyTriangleStripsAsLines( Geometry* geometry, Geometry::Vertex* destination );
         void CopyTriangleFanAsLines( Geometry* geometry, Geometry::Vertex* destination );
         void CopyIndexedTrianglesAsLines( Geometry* geometry, Geometry::Vertex* destination );
@@ -307,11 +307,11 @@ class Renderer
         void MergeVertexData( Geometry::Vertex** destination, const Geometry::Vertex* mainSrc, const Geometry::Vertex* extensionSrc, int index, int extraCount );
         void MergeVertexDataRange( Geometry::Vertex** destination, Geometry* geometry, int count, int extraCount, int offset = 0 );
 
-        void CopyExtendedVertexData( Geometry* geometry, Geometry::Vertex* destination, bool interior );
-        void CopyExtendedTriangleStripsAsLines( Geometry* geometry, Geometry::Vertex* destination );
-        void CopyExtendedTriangleFanAsLines( Geometry* geometry, Geometry::Vertex* destination );
-        void CopyExtendedIndexedTrianglesAsLines( Geometry* geometry, Geometry::Vertex* destination );
-        void CopyExtendedTrianglesAsLines( Geometry* geometry, Geometry::Vertex* destination );
+        void CopyExtendedVertexData( Geometry* geometry, Geometry::Vertex* destination, int extraCount );
+        void CopyExtendedTriangleStripsAsLines( Geometry* geometry, Geometry::Vertex* destination, int extraCount );
+        void CopyExtendedTriangleFanAsLines( Geometry* geometry, Geometry::Vertex* destination, int extraCount );
+        void CopyExtendedIndexedTrianglesAsLines( Geometry* geometry, Geometry::Vertex* destination, int extraCount );
+        void CopyExtendedTrianglesAsLines( Geometry* geometry, Geometry::Vertex* destination, int extraCount );
     
     protected:
         // Returns count at top of the mask count stack
@@ -362,7 +362,6 @@ class Renderer
         RenderData fPrevious;
         U32 fVertexOffset;
         U32 fVertexCount;
-        U32 fVertexExtra;
         U32 fIndexOffset;
         U32 fIndexCount;
         U32 fRenderDataCount;
@@ -371,8 +370,6 @@ class Renderer
         U32 fDegenerateVertexCount;
         U32 fCachedVertexOffset;
         U32 fCachedVertexCount;
-        U32 fCachedVertexExtra;
-		U32 fOffsetCorrection;
         Geometry::PrimitiveType fPreviousPrimitiveType;
         Geometry::Vertex* fCurrentVertex;
         Geometry* fCurrentGeometry;

--- a/librtt/Rtt_DisplayObjectExtensions.cpp
+++ b/librtt/Rtt_DisplayObjectExtensions.cpp
@@ -42,23 +42,15 @@ DisplayObjectExtensions::~DisplayObjectExtensions()
 #ifdef Rtt_PHYSICS
 	if ( fBody )
 	{
-		GroupObject *parent = fOwner.GetParent();
-		if ( Rtt_VERIFY( parent ) )
-		{
-			fBody->SetUserData( NULL );
+		// Always clear UserData to prevent StepWorld from dereferencing
+		// a freed DisplayObject. GetParent() returns NULL for objects
+		// with IsRenderedOffScreen (snapshot.group, canvas cache), which
+		// previously caused SetUserData(NULL) to be skipped.
+		fBody->SetUserData( NULL );
 
-			// Do NOT DestroyBody here.  Instead, at end of StepWorld(), we lazily
-			// detect if the body's userdata is NULL. If it is, we know to destroy
-			// the body.
-			/*
-			Runtime *runtime = static_cast< Runtime* >( Rtt_AllocatorGetUserdata( parent->Allocator() ) );
-			b2World *world = runtime->GetWorld();
-			if ( Rtt_VERIFY( world ) )
-			{
-				world->DestroyBody( fBody );
-			}
-			*/
-		}
+		// Do NOT DestroyBody here.  Instead, at end of StepWorld(), we lazily
+		// detect if the body's userdata is NULL. If it is, we know to destroy
+		// the body.
 	}
 #endif // Rtt_PHYSICS
 }


### PR DESCRIPTION
Same fix as coronalabs/corona#894. Verified on iPhone + macOS.

Unconditional `SetUserData(NULL)` in `~DisplayObjectExtensions` — fixes SIGSEGV when physics bodies are used with snapshot.group or canvas texture cache objects.