### PR TITLE
chore(bgfx): cache version single source + fallback ERROR logs

### DIFF
--- a/librtt/Renderer/Rtt_BgfxCommandBuffer.cpp
+++ b/librtt/Renderer/Rtt_BgfxCommandBuffer.cpp
@@ -923,6 +923,15 @@ BgfxCommandBuffer::ExecuteDraw( const DeferredCmd& cmd )
     bgfx::ProgramHandle programHandle = prog->GetHandle( cmd.programVersion );
     if( !bgfx::isValid( programHandle ) )
     {
+        static int sDrawInvalidCount = 0;
+        if( ++sDrawInvalidCount <= 3 )
+        {
+            ShaderResource* sr = cmd.program
+                ? static_cast<Program*>(cmd.program)->GetShaderResource() : NULL;
+            Rtt_LogException("WARNING: ExecuteDraw skipped: invalid program handle for effect='%s' "
+                "(version=%d) — shader load/compile failed; draw will not appear\n",
+                sr ? sr->GetName().c_str() : "(default)", (int)cmd.programVersion);
+        }
         return;
     }
 
@@ -940,8 +949,6 @@ BgfxCommandBuffer::ExecuteDraw( const DeferredCmd& cmd )
 
     // Apply named uniforms (custom effects)
     ApplyNamedUniforms( cmd );
-
-    // Diagnostic: removed
 
     // Handle TriangleFan conversion
     if( cmd.primitiveType == Geometry::kTriangleFan )
@@ -1064,6 +1071,15 @@ BgfxCommandBuffer::ExecuteDrawIndexed( const DeferredCmd& cmd )
     bgfx::ProgramHandle programHandle = prog->GetHandle( cmd.programVersion );
     if( !bgfx::isValid( programHandle ) )
     {
+        static int sDrawIdxInvalidCount = 0;
+        if( ++sDrawIdxInvalidCount <= 3 )
+        {
+            ShaderResource* sr = cmd.program
+                ? static_cast<Program*>(cmd.program)->GetShaderResource() : NULL;
+            Rtt_LogException("WARNING: ExecuteDrawIndexed skipped: invalid program handle for effect='%s' "
+                "(version=%d) — shader load/compile failed; draw will not appear\n",
+                sr ? sr->GetName().c_str() : "(default)", (int)cmd.programVersion);
+        }
         return;
     }
 

--- a/librtt/Renderer/Rtt_BgfxProgram.cpp
+++ b/librtt/Renderer/Rtt_BgfxProgram.cpp
@@ -13,6 +13,7 @@
 
 #include "Renderer/Rtt_BgfxProgram.h"
 #include "Renderer/Rtt_BgfxShaderCompiler.h"
+#include "Renderer/Rtt_BgfxShaderCacheKey.h"
 #include "Renderer/Rtt_Program.h"
 #include "Display/Rtt_ShaderResource.h"
 #include "Display/Rtt_ShaderTypes.h"
@@ -73,8 +74,8 @@ static const char* GetRuntimeShaderProfileSuffix()
 static void BuildRuntimeShaderCacheKey(char* key, size_t keySize, const char* shaderType,
                                        const char* category, const std::string& name)
 {
-    snprintf(key, keySize, "%s_%s_%s_%s_v7.bin", shaderType, category, name.c_str(),
-             GetRuntimeShaderProfileSuffix());
+    snprintf(key, keySize, "%s_%s_%s_%s_" BGFX_RUNTIME_SHADER_CACHE_VERSION ".bin",
+             shaderType, category, name.c_str(), GetRuntimeShaderProfileSuffix());
 }
 
 // Redirect macros to runtime-selected data
@@ -91,8 +92,8 @@ static const char* GetRuntimeShaderProfileSuffix()
 static void BuildRuntimeShaderCacheKey(char* key, size_t keySize, const char* shaderType,
                                        const char* category, const std::string& name)
 {
-    snprintf(key, keySize, "%s_%s_%s_%s_v7.bin", shaderType, category, name.c_str(),
-             GetRuntimeShaderProfileSuffix());
+    snprintf(key, keySize, "%s_%s_%s_%s_" BGFX_RUNTIME_SHADER_CACHE_VERSION ".bin",
+             shaderType, category, name.c_str(), GetRuntimeShaderProfileSuffix());
 }
 #endif
 

--- a/librtt/Renderer/Rtt_BgfxProgram.cpp
+++ b/librtt/Renderer/Rtt_BgfxProgram.cpp
@@ -600,6 +600,14 @@ bool BgfxProgram::LoadShaderBinary(Program::Version version, const char* type, c
                             name.c_str(), categoryStr);
                     }
                 }
+                else if (strcmp(type, "fs") == 0)
+                {
+                    // FS not found in runtime cache — will fall back to default FS silently.
+                    // This is the exact failure mode for mismatched cache keys: effect renders as blank/white.
+                    Rtt_LogException("WARNING: shader cache miss for effect '%s' FS (key='%s'). "
+                        "Using default FS — custom fragment shader WILL NOT run.\n",
+                        name.c_str(), cacheKey);
+                }
             }
         }
     }
@@ -607,6 +615,15 @@ bool BgfxProgram::LoadShaderBinary(Program::Version version, const char* type, c
     // Fall back to default shaders
     if (!data)
     {
+        if (shaderRes && shaderRes->GetCategory() != ShaderTypes::kCategoryDefault
+            && !shaderRes->GetName().empty())
+        {
+            Rtt_LogException("WARNING: using default %s shader for custom effect '%s' (category '%s') — "
+                "no compiled binary found; the effect will NOT render correctly.\n",
+                type, shaderRes->GetName().c_str(),
+                ShaderTypes::StringForCategory(shaderRes->GetCategory()));
+        }
+
         if (strcmp(type, "vs") == 0)
         {
             data = S_VS_DEFAULT;

--- a/librtt/Renderer/Rtt_BgfxShaderCacheKey.h
+++ b/librtt/Renderer/Rtt_BgfxShaderCacheKey.h
@@ -1,0 +1,9 @@
+#ifndef _Rtt_BgfxShaderCacheKey_H__
+#define _Rtt_BgfxShaderCacheKey_H__
+
+// Single source of truth for the runtime shader cache version suffix.
+// Bump this when shader compilation pipeline changes invalidate old binaries.
+// Used by both Rtt_BgfxShaderCompiler.cpp and Rtt_BgfxProgram.cpp.
+#define BGFX_RUNTIME_SHADER_CACHE_VERSION "v7"
+
+#endif // _Rtt_BgfxShaderCacheKey_H__

--- a/librtt/Renderer/Rtt_BgfxShaderCompiler.cpp
+++ b/librtt/Renderer/Rtt_BgfxShaderCompiler.cpp
@@ -13,6 +13,7 @@
 
 #include "Renderer/Rtt_BgfxShaderCompiler.h"
 #include "Renderer/Rtt_BgfxProgram.h"
+#include "Renderer/Rtt_BgfxShaderCacheKey.h"
 #include "Core/Rtt_Assert.h"
 
 #include <cstdio>
@@ -186,8 +187,8 @@ static const char* GetRuntimeShaderProfileSuffix()
 static void BuildCompiledShaderCacheKey(char* key, size_t keySize, const char* shaderStage,
                                         const char* category, const char* name)
 {
-    snprintf(key, keySize, "%s_%s_%s_%s_v7.bin", shaderStage, category, name,
-             GetRuntimeShaderProfileSuffix());
+    snprintf(key, keySize, "%s_%s_%s_%s_" BGFX_RUNTIME_SHADER_CACHE_VERSION ".bin",
+             shaderStage, category, name, GetRuntimeShaderProfileSuffix());
 }
 
 // Inline bgfx shader compatibility definitions.


### PR DESCRIPTION
## Summary

P40 outline bug 的工程加固，避免下次同类问题再耗 4 小时：

1. **抽 cache key 版本号到 `Rtt_BgfxShaderCacheKey.h`**（`#define BGFX_RUNTIME_SHADER_CACHE_VERSION "v7"`）。原本 `Rtt_BgfxShaderCompiler.cpp` 和 `Rtt_BgfxProgram.cpp` 各 hardcode 一份格式串 — 任何一边 bump 忘了同步另一边就永久 cache miss + 静默 fallback。这次 debug 中真踩了。
2. **加 ERROR/WARNING log 到所有 silent fallback 路径**：
   - `BgfxProgram::LoadShaderBinary` cache miss → WARNING（首次启动正常，第二次启动还出现就有 cache 写入问题）
   - 自定义 effect fallback to default shader → WARNING（含 program 名 + 原因）
   - `BgfxCommandBuffer::ExecuteDraw{Indexed}` invalid program handle → WARNING（前 3 次后限频，避免 hot path 刷屏）

## 反人类设计的根除

之前的 cache miss → bgfx 内部 fallback default shader → 全程无 log，"valid=1 但实际跑的不是你写的 shader"，必须靠硬编码 `vec4(1,0,0,1)` 才能验证 FS 真在跑。本 PR 把这条链上每个静默路径都标出来。

## Test plan

- [x] P40 course 第一关：outline 红绿描边仍正常显示
- [x] logcat 无新增 ERROR / WARNING（说明加的 log 在正常路径不打）
- [ ] 干净安装首次启动：应 log 1 次 cache miss WARNING（正常），第二次启动应 0 次
- [ ] 回归：bgfx-demo `SOLAR2D_TEST` 套件

## 依赖

基于 #PR_A（`fix/p40-revert-mask-pv` 的合并），其中包含 `e94aefbd` 真根因修复。