### PR TITLE
chore(bgfx): eliminate silent fallbacks in resource creation paths

### DIFF
--- a/librtt/Renderer/Rtt_BgfxCommandBuffer.cpp
+++ b/librtt/Renderer/Rtt_BgfxCommandBuffer.cpp
@@ -923,6 +923,15 @@ BgfxCommandBuffer::ExecuteDraw( const DeferredCmd& cmd )
     bgfx::ProgramHandle programHandle = prog->GetHandle( cmd.programVersion );
     if( !bgfx::isValid( programHandle ) )
     {
+        static int sDrawInvalidCount = 0;
+        if( ++sDrawInvalidCount <= 3 )
+        {
+            ShaderResource* sr = cmd.program
+                ? static_cast<Program*>(cmd.program)->GetShaderResource() : NULL;
+            Rtt_LogException("WARNING: ExecuteDraw skipped: invalid program handle for effect='%s' "
+                "(version=%d) — shader load/compile failed; draw will not appear\n",
+                sr ? sr->GetName().c_str() : "(default)", (int)cmd.programVersion);
+        }
         return;
     }
 
@@ -940,8 +949,6 @@ BgfxCommandBuffer::ExecuteDraw( const DeferredCmd& cmd )
 
     // Apply named uniforms (custom effects)
     ApplyNamedUniforms( cmd );
-
-    // Diagnostic: removed
 
     // Handle TriangleFan conversion
     if( cmd.primitiveType == Geometry::kTriangleFan )
@@ -1064,6 +1071,15 @@ BgfxCommandBuffer::ExecuteDrawIndexed( const DeferredCmd& cmd )
     bgfx::ProgramHandle programHandle = prog->GetHandle( cmd.programVersion );
     if( !bgfx::isValid( programHandle ) )
     {
+        static int sDrawIdxInvalidCount = 0;
+        if( ++sDrawIdxInvalidCount <= 3 )
+        {
+            ShaderResource* sr = cmd.program
+                ? static_cast<Program*>(cmd.program)->GetShaderResource() : NULL;
+            Rtt_LogException("WARNING: ExecuteDrawIndexed skipped: invalid program handle for effect='%s' "
+                "(version=%d) — shader load/compile failed; draw will not appear\n",
+                sr ? sr->GetName().c_str() : "(default)", (int)cmd.programVersion);
+        }
         return;
     }
 

--- a/librtt/Renderer/Rtt_BgfxFrameBufferObject.cpp
+++ b/librtt/Renderer/Rtt_BgfxFrameBufferObject.cpp
@@ -98,6 +98,12 @@ BgfxFrameBufferObject::Create( CPUResource* resource )
 	// destroyTextures = false - texture is managed by BgfxTexture
 	fHandle = bgfx::createFrameBuffer( 1, &fTextureHandle, false );
 
+	if( !bgfx::isValid( fHandle ) )
+	{
+		Rtt_LogException( "ERROR: BgfxFrameBufferObject create FAILED (textureHandle.idx=%u, viewId=%u). Offscreen rendering will be black.\n",
+			fTextureHandle.idx, fViewId );
+	}
+
 	DEBUG_PRINT( "%s : bgfx framebuffer handle: %d, view: %d\n",
 				__FUNCTION__,
 				fHandle.idx,
@@ -131,6 +137,12 @@ BgfxFrameBufferObject::Update( CPUResource* resource )
 
 		fTextureHandle = newTextureHandle;
 		fHandle = bgfx::createFrameBuffer( 1, &fTextureHandle, false );
+
+		if( !bgfx::isValid( fHandle ) )
+		{
+			Rtt_LogException( "ERROR: BgfxFrameBufferObject create FAILED during FBO update (textureHandle.idx=%u, viewId=%u). Offscreen rendering will be black.\n",
+				fTextureHandle.idx, fViewId );
+		}
 	}
 }
 

--- a/librtt/Renderer/Rtt_BgfxGeometry.cpp
+++ b/librtt/Renderer/Rtt_BgfxGeometry.cpp
@@ -143,6 +143,12 @@ BgfxGeometry::CreateStatic( Geometry* geometry )
 	const bgfx::Memory* vertexMem = bgfx::copy( vertexData, static_cast<uint32_t>( vertexDataSize ) );
 	fVertexBufferHandle = bgfx::createVertexBuffer( vertexMem, sVertexLayout );
 
+	if( !bgfx::isValid( fVertexBufferHandle ) )
+	{
+		Rtt_LogException( "ERROR: BgfxGeometry createVertexBuffer FAILED (vertexCount=%u size=%zu). Geometry data will not render.\n",
+			vertexCount, vertexDataSize );
+	}
+
 	// Create index buffer if present
 	const Geometry::Index* indexData = geometry->GetIndexData();
 	const U32 indexCount = geometry->GetIndicesAllocated();
@@ -154,6 +160,12 @@ BgfxGeometry::CreateStatic( Geometry* geometry )
 		const bgfx::Memory* indexMem = bgfx::copy( indexData, static_cast<uint32_t>( indexDataSize ) );
 		fIndexBufferHandle = bgfx::createIndexBuffer( indexMem, BGFX_BUFFER_NONE );
 		fHasIndexBuffer = true;
+
+		if( !bgfx::isValid( fIndexBufferHandle ) )
+		{
+			Rtt_LogException( "ERROR: BgfxGeometry createIndexBuffer FAILED (indexCount=%u size=%zu). Geometry data will not render.\n",
+				indexCount, indexDataSize );
+		}
 	}
 
 
@@ -167,22 +179,34 @@ BgfxGeometry::CreateDynamic( Geometry* geometry )
 	const U32 vertexCount = geometry->GetVerticesAllocated();
 	
 	// Create dynamic vertex buffer with resize capability
-	fDynamicVertexBufferHandle = bgfx::createDynamicVertexBuffer( 
-		vertexCount, 
-		sVertexLayout, 
+	fDynamicVertexBufferHandle = bgfx::createDynamicVertexBuffer(
+		vertexCount,
+		sVertexLayout,
 		BGFX_BUFFER_ALLOW_RESIZE
 	);
+
+	if( !bgfx::isValid( fDynamicVertexBufferHandle ) )
+	{
+		Rtt_LogException( "ERROR: BgfxGeometry createDynamicVertexBuffer FAILED (vertexCount=%u). Geometry data will not render.\n",
+			vertexCount );
+	}
 
 	// Create dynamic index buffer if present
 	const Geometry::Index* indexData = geometry->GetIndexData();
 	if( indexData )
 	{
 		const U32 indexCount = geometry->GetIndicesAllocated();
-		fDynamicIndexBufferHandle = bgfx::createDynamicIndexBuffer( 
-			indexCount, 
-			BGFX_BUFFER_ALLOW_RESIZE | BGFX_BUFFER_NONE 
+		fDynamicIndexBufferHandle = bgfx::createDynamicIndexBuffer(
+			indexCount,
+			BGFX_BUFFER_ALLOW_RESIZE | BGFX_BUFFER_NONE
 		);
 		fHasIndexBuffer = true;
+
+		if( !bgfx::isValid( fDynamicIndexBufferHandle ) )
+		{
+			Rtt_LogException( "ERROR: BgfxGeometry createDynamicIndexBuffer FAILED (indexCount=%u). Geometry data will not render.\n",
+				indexCount );
+		}
 	}
 
 	fVertexCount = vertexCount;

--- a/librtt/Renderer/Rtt_BgfxProgram.cpp
+++ b/librtt/Renderer/Rtt_BgfxProgram.cpp
@@ -13,6 +13,7 @@
 
 #include "Renderer/Rtt_BgfxProgram.h"
 #include "Renderer/Rtt_BgfxShaderCompiler.h"
+#include "Renderer/Rtt_BgfxShaderCacheKey.h"
 #include "Renderer/Rtt_Program.h"
 #include "Display/Rtt_ShaderResource.h"
 #include "Display/Rtt_ShaderTypes.h"
@@ -73,8 +74,8 @@ static const char* GetRuntimeShaderProfileSuffix()
 static void BuildRuntimeShaderCacheKey(char* key, size_t keySize, const char* shaderType,
                                        const char* category, const std::string& name)
 {
-    snprintf(key, keySize, "%s_%s_%s_%s_v7.bin", shaderType, category, name.c_str(),
-             GetRuntimeShaderProfileSuffix());
+    snprintf(key, keySize, "%s_%s_%s_%s_" BGFX_RUNTIME_SHADER_CACHE_VERSION ".bin",
+             shaderType, category, name.c_str(), GetRuntimeShaderProfileSuffix());
 }
 
 // Redirect macros to runtime-selected data
@@ -91,8 +92,8 @@ static const char* GetRuntimeShaderProfileSuffix()
 static void BuildRuntimeShaderCacheKey(char* key, size_t keySize, const char* shaderType,
                                        const char* category, const std::string& name)
 {
-    snprintf(key, keySize, "%s_%s_%s_%s_v7.bin", shaderType, category, name.c_str(),
-             GetRuntimeShaderProfileSuffix());
+    snprintf(key, keySize, "%s_%s_%s_%s_" BGFX_RUNTIME_SHADER_CACHE_VERSION ".bin",
+             shaderType, category, name.c_str(), GetRuntimeShaderProfileSuffix());
 }
 #endif
 

--- a/librtt/Renderer/Rtt_BgfxProgram.cpp
+++ b/librtt/Renderer/Rtt_BgfxProgram.cpp
@@ -600,6 +600,14 @@ bool BgfxProgram::LoadShaderBinary(Program::Version version, const char* type, c
                             name.c_str(), categoryStr);
                     }
                 }
+                else if (strcmp(type, "fs") == 0)
+                {
+                    // FS not found in runtime cache — will fall back to default FS silently.
+                    // This is the exact failure mode for mismatched cache keys: effect renders as blank/white.
+                    Rtt_LogException("WARNING: shader cache miss for effect '%s' FS (key='%s'). "
+                        "Using default FS — custom fragment shader WILL NOT run.\n",
+                        name.c_str(), cacheKey);
+                }
             }
         }
     }
@@ -607,6 +615,15 @@ bool BgfxProgram::LoadShaderBinary(Program::Version version, const char* type, c
     // Fall back to default shaders
     if (!data)
     {
+        if (shaderRes && shaderRes->GetCategory() != ShaderTypes::kCategoryDefault
+            && !shaderRes->GetName().empty())
+        {
+            Rtt_LogException("WARNING: using default %s shader for custom effect '%s' (category '%s') — "
+                "no compiled binary found; the effect will NOT render correctly.\n",
+                type, shaderRes->GetName().c_str(),
+                ShaderTypes::StringForCategory(shaderRes->GetCategory()));
+        }
+
         if (strcmp(type, "vs") == 0)
         {
             data = S_VS_DEFAULT;

--- a/librtt/Renderer/Rtt_BgfxProgram.cpp
+++ b/librtt/Renderer/Rtt_BgfxProgram.cpp
@@ -418,10 +418,19 @@ void BgfxProgram::CreateVersion(Program::Version version, VersionData& data)
     {
         Program* prog = static_cast<Program*>(fResource);
         ShaderResource* sr = prog ? prog->GetShaderResource() : NULL;
-        Rtt_LogException("CreateVersion: program=%s valid=%d VS.idx=%d FS.idx=%d version=%d\n",
-                         sr ? sr->GetName().c_str() : "default",
-                         bgfx::isValid(data.fProgram) ? 1 : 0,
-                         data.fVertexShader.idx, data.fFragmentShader.idx, version);
+        bool progValid = bgfx::isValid(data.fProgram);
+        if( progValid )
+        {
+            Rtt_LogException("CreateVersion: program=%s valid=1 VS.idx=%d FS.idx=%d version=%d\n",
+                             sr ? sr->GetName().c_str() : "default",
+                             data.fVertexShader.idx, data.fFragmentShader.idx, version);
+        }
+        else
+        {
+            Rtt_LogException("ERROR: CreateVersion: program=%s valid=0 VS.idx=%d FS.idx=%d version=%d; program creation failed, default shader fallback will be used.\n",
+                             sr ? sr->GetName().c_str() : "default",
+                             data.fVertexShader.idx, data.fFragmentShader.idx, version);
+        }
     }
 
     if (!bgfx::isValid(data.fProgram))
@@ -654,56 +663,38 @@ bool BgfxProgram::LoadShaderBinary(Program::Version version, const char* type, c
 
 void BgfxProgram::CreateUniforms()
 {
-    // Create built-in uniforms (global, created once)
-    // Note: bgfx doesn't support float uniforms directly, so we use Vec4
-    // and pack float values in the .x component
-    
-    fUniformViewProjectionMatrix = bgfx::createUniform(
-        "u_ViewProjectionMatrix", bgfx::UniformType::Mat4);
-    
-    fUniformMaskMatrix0 = bgfx::createUniform("u_MaskMatrix0", bgfx::UniformType::Mat3);
-    fUniformMaskMatrix1 = bgfx::createUniform("u_MaskMatrix1", bgfx::UniformType::Mat3);
-    fUniformMaskMatrix2 = bgfx::createUniform("u_MaskMatrix2", bgfx::UniformType::Mat3);
-    
-    // Float uniforms packed in vec4.x
-    fUniformTotalTime = bgfx::createUniform(
-        "u_TotalTime", bgfx::UniformType::Vec4);
-    fUniformDeltaTime = bgfx::createUniform(
-        "u_DeltaTime", bgfx::UniformType::Vec4);
-    
-    fUniformTexelSize = bgfx::createUniform(
-        "u_TexelSize", bgfx::UniformType::Vec4);
-    
-    // vec2 packed in vec4.xy
-    fUniformContentScale = bgfx::createUniform(
-        "u_ContentScale", bgfx::UniformType::Vec4);
-    fUniformContentSize = bgfx::createUniform(
-        "u_ContentSize", bgfx::UniformType::Vec4);
-    
-    fUniformUserData0 = bgfx::createUniform(
-        "u_UserData0", bgfx::UniformType::Vec4);
-    fUniformUserData1 = bgfx::createUniform(
-        "u_UserData1", bgfx::UniformType::Vec4);
-    fUniformUserData2 = bgfx::createUniform(
-        "u_UserData2", bgfx::UniformType::Vec4);
-    fUniformUserData3 = bgfx::createUniform(
-        "u_UserData3", bgfx::UniformType::Vec4);
-    
-    // Texture flags: .x = 1.0 for alpha-only texture (needs R->A swizzle)
-    fUniformTexFlags = bgfx::createUniform(
-        "u_TexFlags", bgfx::UniformType::Vec4);
+#define BGFX_CREATE_UNIFORM_OR_LOG(field, name, type) \
+    do { (field) = bgfx::createUniform((name), (type)); \
+         if (!bgfx::isValid(field)) Rtt_LogException("ERROR: createUniform '%s' FAILED\n", (name)); \
+    } while (0)
 
-    // Create sampler uniforms
-    fSamplerFill0 = bgfx::createUniform(
-        "u_FillSampler0", bgfx::UniformType::Sampler);
-    fSamplerFill1 = bgfx::createUniform(
-        "u_FillSampler1", bgfx::UniformType::Sampler);
-    fSamplerMask0 = bgfx::createUniform(
-        "u_MaskSampler0", bgfx::UniformType::Sampler);
-    fSamplerMask1 = bgfx::createUniform(
-        "u_MaskSampler1", bgfx::UniformType::Sampler);
-    fSamplerMask2 = bgfx::createUniform(
-        "u_MaskSampler2", bgfx::UniformType::Sampler);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformViewProjectionMatrix, "u_ViewProjectionMatrix", bgfx::UniformType::Mat4);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformMaskMatrix0, "u_MaskMatrix0", bgfx::UniformType::Mat3);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformMaskMatrix1, "u_MaskMatrix1", bgfx::UniformType::Mat3);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformMaskMatrix2, "u_MaskMatrix2", bgfx::UniformType::Mat3);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformTotalTime,  "u_TotalTime",  bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformDeltaTime,  "u_DeltaTime",  bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformTexelSize,  "u_TexelSize",  bgfx::UniformType::Vec4);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformContentScale, "u_ContentScale", bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformContentSize,  "u_ContentSize",  bgfx::UniformType::Vec4);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformUserData0, "u_UserData0", bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformUserData1, "u_UserData1", bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformUserData2, "u_UserData2", bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformUserData3, "u_UserData3", bgfx::UniformType::Vec4);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformTexFlags, "u_TexFlags", bgfx::UniformType::Vec4);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fSamplerFill0, "u_FillSampler0", bgfx::UniformType::Sampler);
+    BGFX_CREATE_UNIFORM_OR_LOG(fSamplerFill1, "u_FillSampler1", bgfx::UniformType::Sampler);
+    BGFX_CREATE_UNIFORM_OR_LOG(fSamplerMask0, "u_MaskSampler0", bgfx::UniformType::Sampler);
+    BGFX_CREATE_UNIFORM_OR_LOG(fSamplerMask1, "u_MaskSampler1", bgfx::UniformType::Sampler);
+    BGFX_CREATE_UNIFORM_OR_LOG(fSamplerMask2, "u_MaskSampler2", bgfx::UniformType::Sampler);
+
+#undef BGFX_CREATE_UNIFORM_OR_LOG
 }
 
 void BgfxProgram::DestroyUniforms()

--- a/librtt/Renderer/Rtt_BgfxRenderer.cpp
+++ b/librtt/Renderer/Rtt_BgfxRenderer.cpp
@@ -705,6 +705,12 @@ BgfxRenderer::CaptureFrameBuffer( RenderingStream & stream, BufferBitmap & bitma
             );
             fStagingW = readW;
             fStagingH = readH;
+
+            if( !bgfx::isValid( fStagingTexture ) )
+            {
+                Rtt_LogException( "ERROR: BgfxRenderer staging texture createTexture2D FAILED (w=%u h=%u). Screen capture will be skipped.\n",
+                    readW, readH );
+            }
         }
 
         if( bgfx::isValid( fStagingTexture ) )
@@ -760,6 +766,16 @@ BgfxRenderer::CaptureFrameBuffer( RenderingStream & stream, BufferBitmap & bitma
                 currentFrame,
                 attempts );
 #endif
+        }
+        else
+        {
+            static int sStagingWarnCount = 0;
+            if( sStagingWarnCount < 3 )
+            {
+                Rtt_LogException( "WARNING: BgfxRenderer staging texture invalid; screen capture will be skipped.\n" );
+                if( ++sStagingWarnCount == 3 )
+                    Rtt_LogException( "(further staging-texture warnings suppressed)\n" );
+            }
         }
 
 #if defined( Rtt_ANDROID_ENV )

--- a/librtt/Renderer/Rtt_BgfxShaderCacheKey.h
+++ b/librtt/Renderer/Rtt_BgfxShaderCacheKey.h
@@ -1,0 +1,9 @@
+#ifndef _Rtt_BgfxShaderCacheKey_H__
+#define _Rtt_BgfxShaderCacheKey_H__
+
+// Single source of truth for the runtime shader cache version suffix.
+// Bump this when shader compilation pipeline changes invalidate old binaries.
+// Used by both Rtt_BgfxShaderCompiler.cpp and Rtt_BgfxProgram.cpp.
+#define BGFX_RUNTIME_SHADER_CACHE_VERSION "v7"
+
+#endif // _Rtt_BgfxShaderCacheKey_H__

--- a/librtt/Renderer/Rtt_BgfxShaderCompiler.cpp
+++ b/librtt/Renderer/Rtt_BgfxShaderCompiler.cpp
@@ -13,6 +13,7 @@
 
 #include "Renderer/Rtt_BgfxShaderCompiler.h"
 #include "Renderer/Rtt_BgfxProgram.h"
+#include "Renderer/Rtt_BgfxShaderCacheKey.h"
 #include "Core/Rtt_Assert.h"
 
 #include <cstdio>
@@ -186,8 +187,8 @@ static const char* GetRuntimeShaderProfileSuffix()
 static void BuildCompiledShaderCacheKey(char* key, size_t keySize, const char* shaderStage,
                                         const char* category, const char* name)
 {
-    snprintf(key, keySize, "%s_%s_%s_%s_v7.bin", shaderStage, category, name,
-             GetRuntimeShaderProfileSuffix());
+    snprintf(key, keySize, "%s_%s_%s_%s_" BGFX_RUNTIME_SHADER_CACHE_VERSION ".bin",
+             shaderStage, category, name, GetRuntimeShaderProfileSuffix());
 }
 
 // Inline bgfx shader compatibility definitions.

--- a/librtt/Renderer/Rtt_BgfxTexture.cpp
+++ b/librtt/Renderer/Rtt_BgfxTexture.cpp
@@ -274,7 +274,13 @@ BgfxTexture::Create( CPUResource* resource )
 			static_cast<uint16_t>(w),
 			static_cast<uint16_t>(h),
 			false, 1, format, flags);
-		
+
+		if( !bgfx::isValid( fHandle ) )
+		{
+			Rtt_LogException( "ERROR: BgfxTexture Create FAILED (RT path): format=%d w=%u h=%u flags=0x%llx. Render target will be black.\n",
+				(int)format, w, h, (unsigned long long)flags );
+		}
+
 		fCachedFormat = static_cast<S32>( Texture::kRGBA );
 		fCachedWidth = w;
 		fCachedHeight = h;
@@ -449,6 +455,12 @@ BgfxTexture::Update( CPUResource* resource )
 				flags,
 				mem
 			);
+
+			if( !bgfx::isValid( fHandle ) )
+			{
+				Rtt_LogException( "ERROR: BgfxTexture Update createTexture2D FAILED (format=%d w=%u h=%u samplerFlags=0x%x). Texture will not render.\n",
+					(int)actualFormat, w, h, fSamplerFlags );
+			}
 
 			fCachedFormat = static_cast<S32>( format );
 			fCachedWidth = w;


### PR DESCRIPTION
## Summary

延续 PR #32 的"杜绝静默失败"工作，把 bgfx 集成层剩余 7 类 silent error path 全部加上 ERROR/WARNING log。3 个独立 commit：

### `fbdc8566` FBO / Texture / Geometry create failures（High + Med）
- `Rtt_BgfxFrameBufferObject.cpp:107, 141`：`createFrameBuffer` 后加 `isValid` + ERROR log（FBO 失败 = 离屏渲染全黑，原本完全静默）
- `Rtt_BgfxTexture.cpp:268-279` RT 分支：补齐 `isValid` 检查，与同函数 normal 路径（L283）统一
- `Rtt_BgfxTexture.cpp:443` sampler/expanded mem 路径：同上
- `Rtt_BgfxGeometry.cpp:147 / 158 / 173 / 184`：4 个 buffer create 全部加 ERROR log（vertex / index / dynamic vertex / dynamic index）

### `e4935259` staging texture + 限频 WARNING
- `Rtt_BgfxRenderer.cpp:684`：staging texture（screen capture 用）创建失败加 ERROR log
- `Rtt_BgfxRenderer.cpp:693`：invalid 时跳过 blit 路径加 rate-limited WARNING（前 3 次）

### `2b3ffdcd` program / uniform creation
- `Rtt_BgfxProgram::CreateVersion` 日志按 `valid` 分级（valid=0 → ERROR + 提示 fallback；valid=1 维持 INFO）
- `BgfxProgram::CreateUniforms` 30+ 核心 uniform 通过新 helper `CREATE_UNIFORM_OR_LOG` 批量加 isValid 检查 + ERROR log

## 反人类设计的根除（延续）

P40 outline bug 浪费 4 小时的根本原因之一就是 bgfx + Solar2D 集成层错误路径**全程静默**："看上去 valid=1，实际跑的不是你写的 shader / 没渲染的东西就是黑屏"。本 PR 把还没修过的 7 类静默路径全部 surface。

## Test plan

- [x] P40 (Mali Vulkan) course 第一关：outline 红绿描边仍正常显示
- [x] Happy path 启动 + 进 course：30s logcat 无新增 ERROR/WARNING（说明加的 log 在正常路径不打）
- [ ] 干净安装首次启动：cache miss WARNING 应 log 1 次（来自 PR #32），第二次启动应 0 次
- [ ] 回归：bgfx-demo `SOLAR2D_TEST` 全量套件

## 依赖

基于 PR #32（`chore/bgfx-shader-cache-version-and-error-logs`），其上是 PR #31。