### PR TITLE
fix(bgfx): restore stored-on-GPU geometry transient path (4-29 fix)

### DIFF
--- a/librtt/Renderer/Rtt_BgfxGeometry.cpp
+++ b/librtt/Renderer/Rtt_BgfxGeometry.cpp
@@ -370,23 +370,25 @@ BgfxGeometry::Update( CPUResource* resource )
 	Rtt_ASSERT( CPUResource::kGeometry == resource->GetType() );
 	Geometry* geometry = static_cast<Geometry*>( resource );
 
+	// Phase 16 experiment: force stored-on-GPU geometry to use transient path
+	// to bypass Adreno 530 GLES DynamicVertexBuffer update latency.
+	// Hypothesis: bgfx::update() doesn't reach GPU before the next render reads
+	// the buffer, leaving stale (initial white) vertex colors after fade-out.
+	if( fWasStoredOnGPU && !fIsTransient )
+	{
+		DestroyDynamic();
+		DestroyStatic();
+		fIsTransient = true;
+		fVertexCount = geometry->GetVerticesAllocated();
+	}
+
 	if( fIsTransient )
 	{
 		UpdateTransient( geometry );
 	}
 	else if( fIsDynamic )
 	{
-		// Auto-promote: if this was a StoredOnGPU geometry that was converted
-		// to dynamic (on first update), and it has been stable for many frames,
-		// promote back to static for optimal GPU rendering performance.
-		if( fWasStoredOnGPU && (sFrameCount - fLastUpdateFrame) > kPromotionThreshold )
-		{
-			PromoteToStatic( geometry );
-		}
-		else
-		{
-			UpdateDynamic( geometry );
-		}
+		UpdateDynamic( geometry );
 		fLastUpdateFrame = sFrameCount;
 	}
 	else


### PR DESCRIPTION
## Summary

cherry-pick `c06e71f3` from `fix/s7-013-phase13-paintlog` (4-29).

## Why

This 4-29 fix was never merged into `bgfx-solar2d`. Resulted in PR #39 P40 Vulkan regression (level 1 road texture wrong, tutorial assembly outline white block).

## Source

`c06e71f3 fix(bgfx): force stored-on-GPU geometry to transient path`

## Audit context

`/Users/yee/data/dev/app/labo/game_engine/issues/branch-audit-2026-05-06/audit-report.md`

## Test plan

- [ ] P40 Vulkan tank manual verification needed before merge.
- chore 5 条 logging 改动单独 PR 跟进（撞 v7→v8 升版冲突）。

---

**do not merge until P40 Vulkan tank manual verification confirms regression resolved**
