### PR TITLE
fix(bgfx): bump shader compiler cache key v7→v8 for mask-pv-v3 layout

### DIFF
--- a/librtt/Renderer/Rtt_BgfxShaderCompiler.cpp
+++ b/librtt/Renderer/Rtt_BgfxShaderCompiler.cpp
@@ -186,7 +186,7 @@ static const char* GetRuntimeShaderProfileSuffix()
 static void BuildCompiledShaderCacheKey(char* key, size_t keySize, const char* shaderStage,
                                         const char* category, const char* name)
 {
-    snprintf(key, keySize, "%s_%s_%s_%s_v7.bin", shaderStage, category, name,
+    snprintf(key, keySize, "%s_%s_%s_%s_v8.bin", shaderStage, category, name,
              GetRuntimeShaderProfileSuffix());
 }
 


### PR DESCRIPTION
## Summary

Hotfix for P40 (Mali-G76 Vulkan) tank regression introduced by PR #37 (mask-pv-v3 vertex layout 44B→68B).

PR #37 bumped the shader cache key in `Rtt_BgfxProgram.cpp` (v7→v8) but missed the same hardcoded `"v7.bin"` constant in `Rtt_BgfxShaderCompiler.cpp:189`. Result: shader compiler still loaded stale v7 cached binaries that didn't match the new vertex layout, causing wrong rendering on real devices (tank Stage 1 ground texture corrupt + tutorial assembly outline white).

## Root cause

- `Rtt_BgfxProgram.cpp:76,94` — already updated to `v8.bin` in commit `97e5d2fe`
- `Rtt_BgfxShaderCompiler.cpp:189` — left at `v7.bin` (this fix bumps to `v8.bin`)

The compiler reads stale v7 binaries when v8 layout requires recompilation, so geometry uploaded via the new 68B layout was decoded by shaders compiled for the old 44B layout.

## Test plan

- [x] librtt Debug build PASS
- [x] tank APK built + installed on P40 KXU0221225000888
- [x] User manual verification on P40: Stage 1 ground texture + tutorial outline both correct
- [ ] CI: bgfx libs / Daily Build / Android template / iOS template

## Related

- Reproducing PR: #37 (mask-pv-v3 merged 2026-05-06 12:15 UTC)
- Companion fix: #40 (force stored-on-GPU geometry to transient, merged 2026-05-06 10:11 UTC)
- Blocks: #39 (bgfx mainstream sync) — held draft pending this hotfix