### PR TITLE
chore(bgfx): centralize shader cache key + add logging for silent fallbacks

### DIFF
--- a/librtt/Renderer/Rtt_BgfxCommandBuffer.cpp
+++ b/librtt/Renderer/Rtt_BgfxCommandBuffer.cpp
@@ -927,6 +927,15 @@ BgfxCommandBuffer::ExecuteDraw( const DeferredCmd& cmd )
     bgfx::ProgramHandle programHandle = prog->GetHandle( cmd.programVersion );
     if( !bgfx::isValid( programHandle ) )
     {
+        static int sDrawInvalidCount = 0;
+        if( ++sDrawInvalidCount <= 3 )
+        {
+            ShaderResource* sr = cmd.program
+                ? static_cast<Program*>(cmd.program)->GetShaderResource() : NULL;
+            Rtt_LogException("WARNING: ExecuteDraw skipped: invalid program handle for effect='%s' "
+                "(version=%d) — shader load/compile failed; draw will not appear\n",
+                sr ? sr->GetName().c_str() : "(default)", (int)cmd.programVersion);
+        }
         return;
     }
 
@@ -1066,6 +1075,15 @@ BgfxCommandBuffer::ExecuteDrawIndexed( const DeferredCmd& cmd )
     bgfx::ProgramHandle programHandle = prog->GetHandle( cmd.programVersion );
     if( !bgfx::isValid( programHandle ) )
     {
+        static int sDrawIdxInvalidCount = 0;
+        if( ++sDrawIdxInvalidCount <= 3 )
+        {
+            ShaderResource* sr = cmd.program
+                ? static_cast<Program*>(cmd.program)->GetShaderResource() : NULL;
+            Rtt_LogException("WARNING: ExecuteDrawIndexed skipped: invalid program handle for effect='%s' "
+                "(version=%d) — shader load/compile failed; draw will not appear\n",
+                sr ? sr->GetName().c_str() : "(default)", (int)cmd.programVersion);
+        }
         return;
     }
 

--- a/librtt/Renderer/Rtt_BgfxFrameBufferObject.cpp
+++ b/librtt/Renderer/Rtt_BgfxFrameBufferObject.cpp
@@ -98,6 +98,12 @@ BgfxFrameBufferObject::Create( CPUResource* resource )
 	// destroyTextures = false - texture is managed by BgfxTexture
 	fHandle = bgfx::createFrameBuffer( 1, &fTextureHandle, false );
 
+	if( !bgfx::isValid( fHandle ) )
+	{
+		Rtt_LogException( "ERROR: BgfxFrameBufferObject create FAILED (textureHandle.idx=%u, viewId=%u). Offscreen rendering will be black.\n",
+			fTextureHandle.idx, fViewId );
+	}
+
 	DEBUG_PRINT( "%s : bgfx framebuffer handle: %d, view: %d\n",
 				__FUNCTION__,
 				fHandle.idx,
@@ -131,6 +137,12 @@ BgfxFrameBufferObject::Update( CPUResource* resource )
 
 		fTextureHandle = newTextureHandle;
 		fHandle = bgfx::createFrameBuffer( 1, &fTextureHandle, false );
+
+		if( !bgfx::isValid( fHandle ) )
+		{
+			Rtt_LogException( "ERROR: BgfxFrameBufferObject create FAILED during FBO update (textureHandle.idx=%u, viewId=%u). Offscreen rendering will be black.\n",
+				fTextureHandle.idx, fViewId );
+		}
 	}
 }
 

--- a/librtt/Renderer/Rtt_BgfxGeometry.cpp
+++ b/librtt/Renderer/Rtt_BgfxGeometry.cpp
@@ -148,6 +148,12 @@ BgfxGeometry::CreateStatic( Geometry* geometry )
 	const bgfx::Memory* vertexMem = bgfx::copy( vertexData, static_cast<uint32_t>( vertexDataSize ) );
 	fVertexBufferHandle = bgfx::createVertexBuffer( vertexMem, sVertexLayout );
 
+	if( !bgfx::isValid( fVertexBufferHandle ) )
+	{
+		Rtt_LogException( "ERROR: BgfxGeometry createVertexBuffer FAILED (vertexCount=%u size=%zu). Geometry data will not render.\n",
+			vertexCount, vertexDataSize );
+	}
+
 	// Create index buffer if present
 	const Geometry::Index* indexData = geometry->GetIndexData();
 	const U32 indexCount = geometry->GetIndicesAllocated();
@@ -159,6 +165,12 @@ BgfxGeometry::CreateStatic( Geometry* geometry )
 		const bgfx::Memory* indexMem = bgfx::copy( indexData, static_cast<uint32_t>( indexDataSize ) );
 		fIndexBufferHandle = bgfx::createIndexBuffer( indexMem, BGFX_BUFFER_NONE );
 		fHasIndexBuffer = true;
+
+		if( !bgfx::isValid( fIndexBufferHandle ) )
+		{
+			Rtt_LogException( "ERROR: BgfxGeometry createIndexBuffer FAILED (indexCount=%u size=%zu). Geometry data will not render.\n",
+				indexCount, indexDataSize );
+		}
 	}
 
 
@@ -172,22 +184,34 @@ BgfxGeometry::CreateDynamic( Geometry* geometry )
 	const U32 vertexCount = geometry->GetVerticesAllocated();
 	
 	// Create dynamic vertex buffer with resize capability
-	fDynamicVertexBufferHandle = bgfx::createDynamicVertexBuffer( 
-		vertexCount, 
-		sVertexLayout, 
+	fDynamicVertexBufferHandle = bgfx::createDynamicVertexBuffer(
+		vertexCount,
+		sVertexLayout,
 		BGFX_BUFFER_ALLOW_RESIZE
 	);
+
+	if( !bgfx::isValid( fDynamicVertexBufferHandle ) )
+	{
+		Rtt_LogException( "ERROR: BgfxGeometry createDynamicVertexBuffer FAILED (vertexCount=%u). Geometry data will not render.\n",
+			vertexCount );
+	}
 
 	// Create dynamic index buffer if present
 	const Geometry::Index* indexData = geometry->GetIndexData();
 	if( indexData )
 	{
 		const U32 indexCount = geometry->GetIndicesAllocated();
-		fDynamicIndexBufferHandle = bgfx::createDynamicIndexBuffer( 
-			indexCount, 
-			BGFX_BUFFER_ALLOW_RESIZE | BGFX_BUFFER_NONE 
+		fDynamicIndexBufferHandle = bgfx::createDynamicIndexBuffer(
+			indexCount,
+			BGFX_BUFFER_ALLOW_RESIZE | BGFX_BUFFER_NONE
 		);
 		fHasIndexBuffer = true;
+
+		if( !bgfx::isValid( fDynamicIndexBufferHandle ) )
+		{
+			Rtt_LogException( "ERROR: BgfxGeometry createDynamicIndexBuffer FAILED (indexCount=%u). Geometry data will not render.\n",
+				indexCount );
+		}
 	}
 
 	fVertexCount = vertexCount;

--- a/librtt/Renderer/Rtt_BgfxProgram.cpp
+++ b/librtt/Renderer/Rtt_BgfxProgram.cpp
@@ -682,6 +682,14 @@ bool BgfxProgram::LoadShaderBinary(Program::Version version, const char* type, c
                             name.c_str(), categoryStr);
                     }
                 }
+                else if (strcmp(type, "fs") == 0)
+                {
+                    // FS not found in runtime cache — will fall back to default FS silently.
+                    // This is the exact failure mode for mismatched cache keys: effect renders as blank/white.
+                    Rtt_LogException("WARNING: shader cache miss for effect '%s' FS (key='%s'). "
+                        "Using default FS — custom fragment shader WILL NOT run.\n",
+                        name.c_str(), cacheKey);
+                }
             }
         }
     }
@@ -689,6 +697,15 @@ bool BgfxProgram::LoadShaderBinary(Program::Version version, const char* type, c
     // Fall back to default shaders
     if (!data)
     {
+        if (shaderRes && shaderRes->GetCategory() != ShaderTypes::kCategoryDefault
+            && !shaderRes->GetName().empty())
+        {
+            Rtt_LogException("WARNING: using default %s shader for custom effect '%s' (category '%s') — "
+                "no compiled binary found; the effect will NOT render correctly.\n",
+                type, shaderRes->GetName().c_str(),
+                ShaderTypes::StringForCategory(shaderRes->GetCategory()));
+        }
+
         if (strcmp(type, "vs") == 0)
         {
             data = PickDefaultVSData(version);

--- a/librtt/Renderer/Rtt_BgfxProgram.cpp
+++ b/librtt/Renderer/Rtt_BgfxProgram.cpp
@@ -13,6 +13,7 @@
 
 #include "Renderer/Rtt_BgfxProgram.h"
 #include "Renderer/Rtt_BgfxShaderCompiler.h"
+#include "Renderer/Rtt_BgfxShaderCacheKey.h"
 #include "Renderer/Rtt_Program.h"
 #include "Display/Rtt_ShaderResource.h"
 #include "Display/Rtt_ShaderTypes.h"
@@ -71,11 +72,10 @@ static const char* GetRuntimeShaderProfileSuffix()
 static void BuildRuntimeShaderCacheKey(char* key, size_t keySize, const char* shaderType,
                                        const char* category, const std::string& name)
 {
-    // 008 mask-PV: v8 — vertex layout grew from 44 to 68 bytes (added
-    // TexCoord2/3/4 mask UV slots). Effect shaders runtime-compiled under
-    // the old layout would map attributes wrong, so invalidate the cache.
-    snprintf(key, keySize, "%s_%s_%s_%s_v8.bin", shaderType, category, name.c_str(),
-             GetRuntimeShaderProfileSuffix());
+    // Cache key version is centralized in Rtt_BgfxShaderCacheKey.h.
+    // Currently v8 (mask-PV layout, 68B vertex; bump on any layout change).
+    snprintf(key, keySize, "%s_%s_%s_%s_" BGFX_RUNTIME_SHADER_CACHE_VERSION ".bin",
+             shaderType, category, name.c_str(), GetRuntimeShaderProfileSuffix());
 }
 
 // FS stays single-binary; mask count is gated at runtime via u_TexFlags.y.
@@ -90,11 +90,10 @@ static const char* GetRuntimeShaderProfileSuffix()
 static void BuildRuntimeShaderCacheKey(char* key, size_t keySize, const char* shaderType,
                                        const char* category, const std::string& name)
 {
-    // 008 mask-PV: v8 — vertex layout grew from 44 to 68 bytes (added
-    // TexCoord2/3/4 mask UV slots). Effect shaders runtime-compiled under
-    // the old layout would map attributes wrong, so invalidate the cache.
-    snprintf(key, keySize, "%s_%s_%s_%s_v8.bin", shaderType, category, name.c_str(),
-             GetRuntimeShaderProfileSuffix());
+    // Cache key version is centralized in Rtt_BgfxShaderCacheKey.h.
+    // Currently v8 (mask-PV layout, 68B vertex; bump on any layout change).
+    snprintf(key, keySize, "%s_%s_%s_%s_" BGFX_RUNTIME_SHADER_CACHE_VERSION ".bin",
+             shaderType, category, name.c_str(), GetRuntimeShaderProfileSuffix());
 }
 #endif
 

--- a/librtt/Renderer/Rtt_BgfxProgram.cpp
+++ b/librtt/Renderer/Rtt_BgfxProgram.cpp
@@ -418,10 +418,19 @@ void BgfxProgram::CreateVersion(Program::Version version, VersionData& data)
     {
         Program* prog = static_cast<Program*>(fResource);
         ShaderResource* sr = prog ? prog->GetShaderResource() : NULL;
-        Rtt_LogException("CreateVersion: program=%s valid=%d VS.idx=%d FS.idx=%d version=%d\n",
-                         sr ? sr->GetName().c_str() : "default",
-                         bgfx::isValid(data.fProgram) ? 1 : 0,
-                         data.fVertexShader.idx, data.fFragmentShader.idx, version);
+        bool progValid = bgfx::isValid(data.fProgram);
+        if( progValid )
+        {
+            Rtt_LogException("CreateVersion: program=%s valid=1 VS.idx=%d FS.idx=%d version=%d\n",
+                             sr ? sr->GetName().c_str() : "default",
+                             data.fVertexShader.idx, data.fFragmentShader.idx, version);
+        }
+        else
+        {
+            Rtt_LogException("ERROR: CreateVersion: program=%s valid=0 VS.idx=%d FS.idx=%d version=%d; program creation failed, default shader fallback will be used.\n",
+                             sr ? sr->GetName().c_str() : "default",
+                             data.fVertexShader.idx, data.fFragmentShader.idx, version);
+        }
     }
 
     if (!bgfx::isValid(data.fProgram))
@@ -735,56 +744,38 @@ bool BgfxProgram::LoadShaderBinary(Program::Version version, const char* type, c
 
 void BgfxProgram::CreateUniforms()
 {
-    // Create built-in uniforms (global, created once)
-    // Note: bgfx doesn't support float uniforms directly, so we use Vec4
-    // and pack float values in the .x component
-    
-    fUniformViewProjectionMatrix = bgfx::createUniform(
-        "u_ViewProjectionMatrix", bgfx::UniformType::Mat4);
-    
-    fUniformMaskMatrix0 = bgfx::createUniform("u_MaskMatrix0", bgfx::UniformType::Mat3);
-    fUniformMaskMatrix1 = bgfx::createUniform("u_MaskMatrix1", bgfx::UniformType::Mat3);
-    fUniformMaskMatrix2 = bgfx::createUniform("u_MaskMatrix2", bgfx::UniformType::Mat3);
-    
-    // Float uniforms packed in vec4.x
-    fUniformTotalTime = bgfx::createUniform(
-        "u_TotalTime", bgfx::UniformType::Vec4);
-    fUniformDeltaTime = bgfx::createUniform(
-        "u_DeltaTime", bgfx::UniformType::Vec4);
-    
-    fUniformTexelSize = bgfx::createUniform(
-        "u_TexelSize", bgfx::UniformType::Vec4);
-    
-    // vec2 packed in vec4.xy
-    fUniformContentScale = bgfx::createUniform(
-        "u_ContentScale", bgfx::UniformType::Vec4);
-    fUniformContentSize = bgfx::createUniform(
-        "u_ContentSize", bgfx::UniformType::Vec4);
-    
-    fUniformUserData0 = bgfx::createUniform(
-        "u_UserData0", bgfx::UniformType::Vec4);
-    fUniformUserData1 = bgfx::createUniform(
-        "u_UserData1", bgfx::UniformType::Vec4);
-    fUniformUserData2 = bgfx::createUniform(
-        "u_UserData2", bgfx::UniformType::Vec4);
-    fUniformUserData3 = bgfx::createUniform(
-        "u_UserData3", bgfx::UniformType::Vec4);
-    
-    // Texture flags: .x = 1.0 for alpha-only texture (needs R->A swizzle)
-    fUniformTexFlags = bgfx::createUniform(
-        "u_TexFlags", bgfx::UniformType::Vec4);
+#define BGFX_CREATE_UNIFORM_OR_LOG(field, name, type) \
+    do { (field) = bgfx::createUniform((name), (type)); \
+         if (!bgfx::isValid(field)) Rtt_LogException("ERROR: createUniform '%s' FAILED\n", (name)); \
+    } while (0)
 
-    // Create sampler uniforms
-    fSamplerFill0 = bgfx::createUniform(
-        "u_FillSampler0", bgfx::UniformType::Sampler);
-    fSamplerFill1 = bgfx::createUniform(
-        "u_FillSampler1", bgfx::UniformType::Sampler);
-    fSamplerMask0 = bgfx::createUniform(
-        "u_MaskSampler0", bgfx::UniformType::Sampler);
-    fSamplerMask1 = bgfx::createUniform(
-        "u_MaskSampler1", bgfx::UniformType::Sampler);
-    fSamplerMask2 = bgfx::createUniform(
-        "u_MaskSampler2", bgfx::UniformType::Sampler);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformViewProjectionMatrix, "u_ViewProjectionMatrix", bgfx::UniformType::Mat4);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformMaskMatrix0, "u_MaskMatrix0", bgfx::UniformType::Mat3);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformMaskMatrix1, "u_MaskMatrix1", bgfx::UniformType::Mat3);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformMaskMatrix2, "u_MaskMatrix2", bgfx::UniformType::Mat3);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformTotalTime,  "u_TotalTime",  bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformDeltaTime,  "u_DeltaTime",  bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformTexelSize,  "u_TexelSize",  bgfx::UniformType::Vec4);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformContentScale, "u_ContentScale", bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformContentSize,  "u_ContentSize",  bgfx::UniformType::Vec4);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformUserData0, "u_UserData0", bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformUserData1, "u_UserData1", bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformUserData2, "u_UserData2", bgfx::UniformType::Vec4);
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformUserData3, "u_UserData3", bgfx::UniformType::Vec4);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fUniformTexFlags, "u_TexFlags", bgfx::UniformType::Vec4);
+
+    BGFX_CREATE_UNIFORM_OR_LOG(fSamplerFill0, "u_FillSampler0", bgfx::UniformType::Sampler);
+    BGFX_CREATE_UNIFORM_OR_LOG(fSamplerFill1, "u_FillSampler1", bgfx::UniformType::Sampler);
+    BGFX_CREATE_UNIFORM_OR_LOG(fSamplerMask0, "u_MaskSampler0", bgfx::UniformType::Sampler);
+    BGFX_CREATE_UNIFORM_OR_LOG(fSamplerMask1, "u_MaskSampler1", bgfx::UniformType::Sampler);
+    BGFX_CREATE_UNIFORM_OR_LOG(fSamplerMask2, "u_MaskSampler2", bgfx::UniformType::Sampler);
+
+#undef BGFX_CREATE_UNIFORM_OR_LOG
 }
 
 void BgfxProgram::DestroyUniforms()

--- a/librtt/Renderer/Rtt_BgfxRenderer.cpp
+++ b/librtt/Renderer/Rtt_BgfxRenderer.cpp
@@ -737,6 +737,12 @@ BgfxRenderer::CaptureFrameBuffer( RenderingStream & stream, BufferBitmap & bitma
             );
             fStagingW = readW;
             fStagingH = readH;
+
+            if( !bgfx::isValid( fStagingTexture ) )
+            {
+                Rtt_LogException( "ERROR: BgfxRenderer staging texture createTexture2D FAILED (w=%u h=%u). Screen capture will be skipped.\n",
+                    readW, readH );
+            }
         }
 
         if( bgfx::isValid( fStagingTexture ) )
@@ -792,6 +798,16 @@ BgfxRenderer::CaptureFrameBuffer( RenderingStream & stream, BufferBitmap & bitma
                 currentFrame,
                 attempts );
 #endif
+        }
+        else
+        {
+            static int sStagingWarnCount = 0;
+            if( sStagingWarnCount < 3 )
+            {
+                Rtt_LogException( "WARNING: BgfxRenderer staging texture invalid; screen capture will be skipped.\n" );
+                if( ++sStagingWarnCount == 3 )
+                    Rtt_LogException( "(further staging-texture warnings suppressed)\n" );
+            }
         }
 
 #if defined( Rtt_ANDROID_ENV )

--- a/librtt/Renderer/Rtt_BgfxShaderCacheKey.h
+++ b/librtt/Renderer/Rtt_BgfxShaderCacheKey.h
@@ -1,0 +1,14 @@
+#ifndef _Rtt_BgfxShaderCacheKey_H__
+#define _Rtt_BgfxShaderCacheKey_H__
+
+// Single source of truth for the runtime shader cache version suffix.
+// Bump this when shader compilation pipeline changes invalidate old binaries.
+// Used by both Rtt_BgfxShaderCompiler.cpp and Rtt_BgfxProgram.cpp.
+//
+// History:
+//   v8 — 008 mask-PV: vertex layout grew from 44 to 68 bytes (added
+//        TexCoord2/3/4 mask UV slots). Effect shaders runtime-compiled under
+//        the old layout would map attributes wrong, so invalidate the cache.
+#define BGFX_RUNTIME_SHADER_CACHE_VERSION "v8"
+
+#endif // _Rtt_BgfxShaderCacheKey_H__

--- a/librtt/Renderer/Rtt_BgfxShaderCompiler.cpp
+++ b/librtt/Renderer/Rtt_BgfxShaderCompiler.cpp
@@ -13,6 +13,7 @@
 
 #include "Renderer/Rtt_BgfxShaderCompiler.h"
 #include "Renderer/Rtt_BgfxProgram.h"
+#include "Renderer/Rtt_BgfxShaderCacheKey.h"
 #include "Core/Rtt_Assert.h"
 
 #include <cstdio>
@@ -186,8 +187,8 @@ static const char* GetRuntimeShaderProfileSuffix()
 static void BuildCompiledShaderCacheKey(char* key, size_t keySize, const char* shaderStage,
                                         const char* category, const char* name)
 {
-    snprintf(key, keySize, "%s_%s_%s_%s_v8.bin", shaderStage, category, name,
-             GetRuntimeShaderProfileSuffix());
+    snprintf(key, keySize, "%s_%s_%s_%s_" BGFX_RUNTIME_SHADER_CACHE_VERSION ".bin",
+             shaderStage, category, name, GetRuntimeShaderProfileSuffix());
 }
 
 // Inline bgfx shader compatibility definitions.

--- a/librtt/Renderer/Rtt_BgfxTexture.cpp
+++ b/librtt/Renderer/Rtt_BgfxTexture.cpp
@@ -274,7 +274,13 @@ BgfxTexture::Create( CPUResource* resource )
 			static_cast<uint16_t>(w),
 			static_cast<uint16_t>(h),
 			false, 1, format, flags);
-		
+
+		if( !bgfx::isValid( fHandle ) )
+		{
+			Rtt_LogException( "ERROR: BgfxTexture Create FAILED (RT path): format=%d w=%u h=%u flags=0x%llx. Render target will be black.\n",
+				(int)format, w, h, (unsigned long long)flags );
+		}
+
 		fCachedFormat = static_cast<S32>( Texture::kRGBA );
 		fCachedWidth = w;
 		fCachedHeight = h;
@@ -449,6 +455,12 @@ BgfxTexture::Update( CPUResource* resource )
 				flags,
 				mem
 			);
+
+			if( !bgfx::isValid( fHandle ) )
+			{
+				Rtt_LogException( "ERROR: BgfxTexture Update createTexture2D FAILED (format=%d w=%u h=%u samplerFlags=0x%x). Texture will not render.\n",
+					(int)actualFormat, w, h, fSamplerFlags );
+			}
 
 			fCachedFormat = static_cast<S32>( format );
 			fCachedWidth = w;


### PR DESCRIPTION
## Summary

Cherry-picks 5 commits from `chore/bgfx-eliminate-silent-fallbacks` and `chore/bgfx-shader-cache-version-and-error-logs` branches that survived the audit triage as 🟡 recommended.

Two themes:

### 1. Centralize shader cache key (3700dada)
Eliminates the hardcoded `"v7.bin"` / `"v8.bin"` string scattered across 3 sites that caused the regression on 2026-05-06 (PR #41). New `Rtt_BgfxShaderCacheKey.h` is the single source of truth. The header carries the v8 mask-PV layout reasoning that was added in PR #41.

### 2. Logging for silent fallback paths (da03693b / 2b3ffdcd / e4935259 / fbdc8566)
Original author noted "4+ hours of silent debugging" in commit messages. These add WARN/ERROR logs to:
- `Draw` / `DrawIndexed` when program handle invalid (rate-limited 3 times)
- `LoadShaderBinary` FS cache miss / fallback to default
- `CreateVersion` / `CreateUniforms` (all 15 createUniform sites get uniform-name logging via new `BGFX_CREATE_UNIFORM_OR_LOG` macro)
- `CaptureFrameBuffer` staging texture / blit failures
- FBO / RT-texture / dynamic VB-IB `isValid` checks

All commits are append-only logging or pure refactor with no behavioral change. Risk: low.

## Conflict resolution
`3700dada` overlapped with PR #41 on the same line of `BuildRuntimeShaderCacheKey` in `Rtt_BgfxProgram.cpp` (Android + macOS branches) and `BuildCompiledShaderCacheKey` in `Rtt_BgfxShaderCompiler.cpp`. Resolved by combining intents: kept 3700dada's macro path and bumped the macro definition in `Rtt_BgfxShaderCacheKey.h` from `"v7"` to `"v8"`, folding PR #41's mask-PV explanation into a `History:` block in the header.

## Test plan
- [x] `librtt` Debug build PASS (`xcodebuild -scheme librtt -configuration Debug` on macOS)
- [ ] `tests/run_all_tests.sh debug` 28/28 PASS (双后端 GL + bgfx) — to run on review
- [ ] CI: bgfx libs / Daily Build / Android template / iOS template

## Related
- Audit: `issues/branch-audit-2026-05-06/audit-report.md`
- Lessons: 2026-05-06 entry in `tasks/lessons.md` ("Vertex layout 升级必须同步 Shader Cache Key 全部硬编码点")
