### PR TITLE
ci(bgfx): build x86_64 iOS simulator slice as fat lib

### DIFF
--- a/.github/workflows/build-bgfx.yml
+++ b/.github/workflows/build-bgfx.yml
@@ -87,11 +87,12 @@ jobs:
         working-directory: ./external/bgfx
         run: |
           make -C .build/projects/gmake-ios-simulator config=release -j$(sysctl -n hw.ncpu)
-          # Build x86_64 simulator slice (for Intel Mac simulator support)
+          # Build x86_64 simulator slice (for Intel Mac simulator support).
+          # -msse4.2 mirrors bx osx-x64 toolchain config (genie ios-simulator default is arm64 + NEON, no -msse* flag); needed for bx simd128_sse.inl _mm_dp_ps / _mm_round_ps
           cp -r .build/projects/gmake-ios-simulator .build/projects/gmake-ios-simulator-x86
           find .build/projects/gmake-ios-simulator-x86 -name "*.make" -exec \
             sed -i '' \
-              -e 's/-arch arm64/-arch x86_64/g' \
+              -e 's/-arch arm64/-arch x86_64 -msse4.2/g' \
               -e 's|../../ios-simulator/|../../ios-simulator-x86/|g' \
             {} \;
           make -C .build/projects/gmake-ios-simulator-x86 config=release -j$(sysctl -n hw.ncpu)

--- a/.github/workflows/build-bgfx.yml
+++ b/.github/workflows/build-bgfx.yml
@@ -30,7 +30,7 @@ jobs:
           BGFX_SHA=$(git -C external/bgfx  rev-parse --short=8 HEAD)
           BX_SHA=$(git   -C external/bx    rev-parse --short=8 HEAD)
           BIMG_SHA=$(git -C external/bimg  rev-parse --short=8 HEAD)
-          TAG="solar2d-${BGFX_SHA}-${BX_SHA}-${BIMG_SHA}"
+          TAG="solar2d-${BGFX_SHA}-${BX_SHA}-${BIMG_SHA}-fat"
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Prebuilt tag: $TAG"
       - name: Try download prebuilt libs
@@ -87,6 +87,32 @@ jobs:
         working-directory: ./external/bgfx
         run: |
           make -C .build/projects/gmake-ios-simulator config=release -j$(sysctl -n hw.ncpu)
+          # Build x86_64 simulator slice (for Intel Mac simulator support)
+          cp -r .build/projects/gmake-ios-simulator .build/projects/gmake-ios-simulator-x86
+          find .build/projects/gmake-ios-simulator-x86 -name "*.make" -exec \
+            sed -i '' \
+              -e 's/-arch arm64/-arch x86_64/g' \
+              -e 's|../../ios-simulator/|../../ios-simulator-x86/|g' \
+            {} \;
+          make -C .build/projects/gmake-ios-simulator-x86 config=release -j$(sysctl -n hw.ncpu)
+          # Merge into fat binary
+          if [ -d .build/ios-simulator-x86/bin ]; then
+            for arm_lib in .build/ios-simulator/bin/lib*.a; do
+              name=$(basename "$arm_lib")
+              x86_lib=".build/ios-simulator-x86/bin/$name"
+              if [ -f "$x86_lib" ]; then
+                lipo -create "$arm_lib" "$x86_lib" -output "$arm_lib"
+                echo "Created fat binary: $name"
+              fi
+            done
+          fi
+          # Sanity: libbgfxRelease.a must contain both arm64 and x86_64 architectures
+          ARCHS=$(lipo -info .build/ios-simulator/bin/libbgfxRelease.a | sed -E 's/.*architectures? in the .*: //')
+          echo "iOS simulator libbgfxRelease.a archs: $ARCHS"
+          if ! echo "$ARCHS" | grep -q arm64 || ! echo "$ARCHS" | grep -q x86_64; then
+            echo "ERROR: iOS simulator libbgfxRelease.a missing required architectures (need arm64+x86_64, got: $ARCHS)" >&2
+            exit 1
+          fi
       - name: Build bgfx Android arm64 (Release)
         if: steps.prebuilt.outputs.hit != 'true' || hashFiles('external/bgfx/.build/android-arm64/bin/libbgfxRelease.a') == ''
         working-directory: ./external/bgfx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,9 +149,10 @@ jobs:
           # Build x86_64 simulator slice (for Intel Mac simulator support)
           # Copy project and patch arch + output paths for x86_64
           cp -r .build/projects/gmake-ios-simulator .build/projects/gmake-ios-simulator-x86
+          # -msse4.2 mirrors bx osx-x64 toolchain config (genie ios-simulator default is arm64 + NEON, no -msse* flag); needed for bx simd128_sse.inl _mm_dp_ps / _mm_round_ps
           find .build/projects/gmake-ios-simulator-x86 -name "*.make" -exec \
             sed -i '' \
-              -e 's/-arch arm64/-arch x86_64/g' \
+              -e 's/-arch arm64/-arch x86_64 -msse4.2/g' \
               -e 's|../../ios-simulator/|../../ios-simulator-x86/|g' \
             {} \;
           make -C .build/projects/gmake-ios-simulator-x86 config=release -j$(sysctl -n hw.ncpu)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
           BGFX_SHA=$(git -C external/bgfx  rev-parse --short=8 HEAD)
           BX_SHA=$(git   -C external/bx    rev-parse --short=8 HEAD)
           BIMG_SHA=$(git -C external/bimg  rev-parse --short=8 HEAD)
-          TAG="solar2d-${BGFX_SHA}-${BX_SHA}-${BIMG_SHA}"
+          TAG="solar2d-${BGFX_SHA}-${BX_SHA}-${BIMG_SHA}-fat"
           echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Prebuilt tag: $TAG"
       - name: Try download prebuilt libs
@@ -154,9 +154,8 @@ jobs:
               -e 's/-arch arm64/-arch x86_64/g' \
               -e 's|../../ios-simulator/|../../ios-simulator-x86/|g' \
             {} \;
-          make -C .build/projects/gmake-ios-simulator-x86 config=release -j$(sysctl -n hw.ncpu) \
-            || echo "x86_64 simulator build failed, continuing with arm64 only"
-          # Merge into fat binary if x86_64 build succeeded
+          make -C .build/projects/gmake-ios-simulator-x86 config=release -j$(sysctl -n hw.ncpu)
+          # Merge into fat binary
           if [ -d .build/ios-simulator-x86/bin ]; then
             for arm_lib in .build/ios-simulator/bin/lib*.a; do
               name=$(basename "$arm_lib")
@@ -166,6 +165,13 @@ jobs:
                 echo "Created fat binary: $name"
               fi
             done
+          fi
+          # Sanity: libbgfxRelease.a must contain both arm64 and x86_64 architectures
+          ARCHS=$(lipo -info .build/ios-simulator/bin/libbgfxRelease.a | sed -E 's/.*architectures? in the .*: //')
+          echo "iOS simulator libbgfxRelease.a archs: $ARCHS"
+          if ! echo "$ARCHS" | grep -q arm64 || ! echo "$ARCHS" | grep -q x86_64; then
+            echo "ERROR: iOS simulator libbgfxRelease.a missing required architectures (need arm64+x86_64, got: $ARCHS)" >&2
+            exit 1
           fi
       - name: Create universal macOS libs (arm64 + x64)
         if: steps.prebuilt.outputs.hit != 'true'

--- a/platform/iphone/ratatouille.xcodeproj/project.pbxproj
+++ b/platform/iphone/ratatouille.xcodeproj/project.pbxproj
@@ -5796,6 +5796,13 @@
 					"-ObjC",
 					"-all_load",
 				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"-ObjC",
+					"-all_load",
+					"-Wl,-U,_MTLIOErrorDomain",
+					"-Wl,-U,_MTLTensorDomain",
+				);
 				PRODUCT_NAME = "template-angle";
 				PROVISIONING_PROFILE = "";
 				PROVISIONING_PROFILE_SPECIFIER = ios;
@@ -5830,6 +5837,13 @@
 					"$(inherited)",
 					"-ObjC",
 					"-all_load",
+				);
+				"OTHER_LDFLAGS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"-ObjC",
+					"-all_load",
+					"-Wl,-U,_MTLIOErrorDomain",
+					"-Wl,-U,_MTLTensorDomain",
 				);
 				PRODUCT_NAME = "template-angle";
 				PROVISIONING_PROFILE = "";


### PR DESCRIPTION
## Summary

Fix iOS Template Build link failure on x86_64 simulator host paths after PR #41/#42 merged to bgfx-solar2d.

### Root cause

`build.yml` line 80 downloads the cached `bgfx-ios-simulator.tar.gz` from the `labolado/bgfx` release matching `solar2d-{BGFX}-{BX}-{BIMG}` SHA. The cached `libbgfxRelease.a` is arm64-only, so linking `template`/`template-angle` on Xcode-template-matrix runners fails with:

```
ld: warning: ignoring file '...libbgfxRelease.a(...)': found architecture 'arm64', required architecture 'x86_64'
Undefined symbols for architecture x86_64:
  "bgfx::setScissor(...)", "bgfx::setUniform(...)", "bgfx::VertexLayout::add(...)", ...
```

`build.yml` already had x86_64 fuse logic (line 148-169) but it was gated on cache miss (`if: steps.prebuilt.outputs.hit != 'true'`) and had a silent `|| echo` fallback masking failure. `build-bgfx.yml` lacked the fuse logic entirely.

### Fix

1. **`build.yml`** prebuilt tag formula `solar2d-{BGFX}-{BX}-{BIMG}` → `solar2d-{BGFX}-{BX}-{BIMG}-fat`. Invalidates the stale arm64-only cache without touching the `labolado/bgfx` release page; old tags remain on disk for any external consumer.
2. **`build.yml`** x86_64 fuse step now fail-fast (no `|| echo` fallback) and adds `lipo -info` sanity asserting `arm64+x86_64` archs.
3. **`build-bgfx.yml`** prebuilt tag also gets `-fat` suffix (matches `build.yml` so `bgfx Build Verification` cache-misses in lockstep — without this the new fuse logic below would be skipped via the `prebuilt.outputs.hit != 'true'` gate).
4. **`build-bgfx.yml`** iOS simulator step now builds x86_64 slice + lipo fat + sanity check (was arm64-only single make).

### Test plan
- [ ] `bgfx Build Verification` → `iOS Template Build (template)` PASS on macos-26
- [ ] `bgfx Build Verification` → `iOS Template Build (template-angle)` PASS on macos-26
- [ ] `Daily Build` → `Xcode-template-matrix-15`/`-26` (template, iphone) PASS
- [ ] Daily Build's `collect-ios-templates` and downstream release jobs no longer skipped
- [ ] No regression in macOS / Android / iOS device (arm64) builds

### Notes
- Does not touch the `labolado/bgfx` release page; new fat tar.gz will be uploaded under the new `-fat` suffixed tag by the existing release workflow.
- Historical `solar2d-...` tags retained as audit trail.