### PR TITLE
port: MacOS/Windows Plugin support (upstream #902)

### DIFF
--- a/platform/mac/Rtt_OSXAppPackager.h
+++ b/platform/mac/Rtt_OSXAppPackager.h
@@ -53,10 +53,11 @@ class OSXAppPackagerParams : public AppPackagerParams
 							targetPlatform, (char*)"apple", targetVersion, targetDevice, customBuildId, productId,
 							appPackage, isDistributionBuild ),
 		fAppSigningIdentity(appSigningIdentity),
-		fInstallerSigningIdentity(installerSigningIdentity)
+		fInstallerSigningIdentity(installerSigningIdentity),
+		fDistributionMethod(NULL)
 		{
 		}
-		
+
 		// Create a minimal OS X packager params for internal use
 		OSXAppPackagerParams(
 							 const char* appName,
@@ -67,7 +68,10 @@ class OSXAppPackagerParams : public AppPackagerParams
 		: AppPackagerParams(
 							appName, version, "", "", srcDir, dstDir, "",
 							TargetDevice::kOSXPlatform, (char*)"apple", -1, -1, "", "",
-							"", false )
+							"", false ),
+		fAppSigningIdentity(NULL),
+		fInstallerSigningIdentity(NULL),
+		fDistributionMethod(NULL)
 		{
 		}
 		
@@ -83,22 +87,26 @@ class OSXAppPackagerParams : public AppPackagerParams
 		///  <para>Returns null if not assigned yet.</para>
 		/// </returns>
 		Runtime* GetRuntime() const { return fRuntime; }
-		const char* GetAppSigningIdentity( ) { return fAppSigningIdentity; }
-		const char* GetInstallerSigningIdentity( ) { return fInstallerSigningIdentity; }
+		const char* GetAppSigningIdentity() const { return fAppSigningIdentity; }
+		const char* GetInstallerSigningIdentity() const { return fInstallerSigningIdentity; }
 
-		/// <summary>
-		///  <para>Sets a pointer to the Corona runtime associated with the project that is being built.</para>
-		///  <para>The runtime is needed to acquire and unzip its plugins for local builds.</para>
-		/// </summary>
-		/// <param name="value">Pointer to the Corona runtime. Can be null.</param>
+		// distributionMethod controls which build pipeline CoronaBuilder uses:
+		//   "developer"        — standard .app build, unsigned or developer-signed (default)
+		//   "app-store"        — Mac App Store .pkg (upload manually via Transporter)
+		//   "developer-id"     — Developer ID signed .pkg for direct distribution
+		//   "developer-id-dmg" — Developer ID signed .dmg for direct distribution
+		const char* GetDistributionMethod() const { return fDistributionMethod ? fDistributionMethod : "developer"; }
+
 		void SetRuntime(Runtime* value) { fRuntime = value; }
-		void SetAppSigningIdentity(const char * appSigningIdentity ) { fAppSigningIdentity = appSigningIdentity; }
-		void SetInstallerSigningIdentity(const char * installerSigningIdentity ) { fInstallerSigningIdentity = installerSigningIdentity; }
+		void SetAppSigningIdentity(const char* v) { fAppSigningIdentity = v; }
+		void SetInstallerSigningIdentity(const char* v) { fInstallerSigningIdentity = v; }
+		void SetDistributionMethod(const char* v) { fDistributionMethod = v; }
 
 	public:
 		Rtt::Runtime* fRuntime;
 		const char* fAppSigningIdentity;
 		const char* fInstallerSigningIdentity;
+		const char* fDistributionMethod;
 };
 
 class OSXAppPackager : public PlatformAppPackager

--- a/platform/mac/Rtt_OSXAppPackager.mm
+++ b/platform/mac/Rtt_OSXAppPackager.mm
@@ -296,14 +296,15 @@ OSXAppPackager::PrepackagePlugins(OSXAppPackagerParams *params, String& pluginsD
 {
 	int result = PlatformAppPackager::kNoError;
 
-#if !defined( Rtt_NO_GUI )
-	// We don't currently support plugins for CoronaBuilder macOS desktop builds
+	// In GUI (Simulator) builds we use the running Runtime to unzip pre-downloaded plugins.
+	// In headless (CoronaBuilder) builds we use DownloadPluginsHeadless() which drives
+	// BuilderPluginDownloader.lua + CoronaBuilderPluginCollector — the same infrastructure iOS uses.
 
+#if !defined( Rtt_NO_GUI )
 	Runtime *runtime = params->GetRuntime();
 
 	Rtt_TRACE(("OSXAppPackager::PrepackagePlugins: pluginsDir %s", pluginsDir.GetString()));
 
-	// Extract the project's plugins to the "bin" directory.
 	if (runtime != NULL && runtime->RequiresDownloadablePlugins())
 	{
 		// Unzip the project's plugins to an intermediate directory.
@@ -320,7 +321,7 @@ OSXAppPackager::PrepackagePlugins(OSXAppPackagerParams *params, String& pluginsD
 		OSXAppPackagerParams pluginParamsSettings(params->GetAppName(), "", pluginsDir.GetString(), outputDir.GetString());
 
 		bool wasCompiled = CompileScripts(&pluginParamsSettings, outputDir.GetString());
-		
+
 		if (!wasCompiled)
 		{
 			if (Rtt_StringIsEmpty(pluginParamsSettings.GetBuildMessage()))
@@ -331,11 +332,45 @@ OSXAppPackager::PrepackagePlugins(OSXAppPackagerParams *params, String& pluginsD
 			{
 				params->SetBuildMessage(pluginParamsSettings.GetBuildMessage());
 			}
-			
+
 			return PlatformAppPackager::kBuildError;
 		}
 	}
-#endif
+
+#else // Rtt_NO_GUI — headless CoronaBuilder path
+
+	Rtt_TRACE(("OSXAppPackager::PrepackagePlugins (headless): pluginsDir %s", pluginsDir.GetString()));
+
+	// Download and extract plugins into pluginsDir using BuilderPluginDownloader.lua.
+	// All plugin archives are extracted flat into pluginsDir (lua_51/ is merged to root).
+	// Use "macos" — TagForPlatform(kOSXPlatform) — to match CoronaBuilderPluginCollector's
+	// platform fallback chain ("macos" → "mac-sim" → "lua").
+	bool wasDownloaded = DownloadPluginsHeadless(params, "macos", pluginsDir.GetString());
+	if (!wasDownloaded)
+	{
+		return PlatformAppPackager::kLocalPackagingError;
+	}
+
+	// Compile any Lua plugin scripts found in pluginsDir.
+	// OSXPostPackage picks up the compiled .lu files alongside the native dylibs.
+	OSXAppPackagerParams pluginParamsSettings(params->GetAppName(), "", pluginsDir.GetString(), outputDir.GetString());
+
+	bool wasCompiled = CompileScripts(&pluginParamsSettings, outputDir.GetString());
+	if (!wasCompiled)
+	{
+		if (Rtt_StringIsEmpty(pluginParamsSettings.GetBuildMessage()))
+		{
+			params->SetBuildMessage("Failed to compile plugin Lua scripts.");
+		}
+		else
+		{
+			params->SetBuildMessage(pluginParamsSettings.GetBuildMessage());
+		}
+
+		return PlatformAppPackager::kBuildError;
+	}
+
+#endif // Rtt_NO_GUI
 
 	return result;
 }

--- a/platform/shared/Rtt_PlatformAppPackager.cpp
+++ b/platform/shared/Rtt_PlatformAppPackager.cpp
@@ -42,6 +42,7 @@
 #   ifdef Rtt_WIN_ENV
 #	    include "Rtt_WinConsolePlatform.h"
 #   endif
+#	include "Rtt_HTTPClient.h"
 #endif
 
 #include "Rtt_MCrypto.h"
@@ -1370,6 +1371,103 @@ PlatformAppPackager::UnzipPlugins( AppPackagerParams *params, Runtime *runtime, 
 	return wasSuccessful;
 }
 #endif
+
+#if defined( Rtt_NO_GUI )
+
+// Forward declaration for the compiled BuilderPluginDownloader.lua bytecode loader.
+// The symbol is provided by the CoronaBuilder link unit (same pattern as Rtt_DownloadPluginsMain.cpp).
+int luaload_BuilderPluginDownloader( lua_State *L );
+
+bool
+PlatformAppPackager::DownloadPluginsHeadless(
+	AppPackagerParams *params,
+	const char *platform,
+	const char *destinationDirectoryPath )
+{
+	lua_State *L = fVM;
+
+	// Register HTTP helpers, socket libraries, lfs, json, and CoronaBuilderPluginCollector
+	// into this Lua VM so that BuilderPluginDownloader.lua can require them.
+	HTTPClient::registerFetcherModuleLoaders( L );
+
+	// Register a minimal 'builder' module exposing fetch + download.
+	// BuilderPluginDownloader.lua does: local builder = require('builder')
+	// and passes builder.fetch / builder.download to the plugin collector.
+	lua_newtable( L );
+	lua_pushcfunction( L, HTTPClient::fetch );
+	lua_setfield( L, -2, "fetch" );
+	lua_pushcfunction( L, HTTPClient::download );
+	lua_setfield( L, -2, "download" );
+	// Store in package.loaded so require('builder') returns it.
+	lua_getglobal( L, "package" );
+	lua_getfield( L, -1, "loaded" );
+	lua_pushvalue( L, -3 );        // duplicate the builder table
+	lua_setfield( L, -2, "builder" );
+	lua_pop( L, 3 );               // pop: package, loaded, builder table
+
+	// Load BuilderPluginDownloader bytecode (defines DownloadPluginsMain global).
+	Lua::DoBuffer( L, &luaload_BuilderPluginDownloader, NULL );
+
+	// Build path to the project's build.settings file.
+	std::string buildSettingsPath( params->GetSrcDir() );
+	buildSettingsPath += LUA_DIRSEP;
+	buildSettingsPath += "build.settings";
+
+	// Ensure destination directory exists.
+	mkdir( destinationDirectoryPath );
+
+	// Call DownloadPluginsMain(args, user, buildYear, buildRevision).
+	// args table layout (1-indexed in Lua):
+	//   [1] = "download"            (subcommand)
+	//   [2] = platform              ("win32" or "osx")
+	//   [3] = buildSettingsPath     (path to build.settings)
+	//   [4] = destinationPath       (where plugin files are extracted)
+	lua_getglobal( L, "DownloadPluginsMain" );
+	if ( !lua_isfunction( L, -1 ) )
+	{
+		lua_pop( L, 1 );
+		params->SetBuildMessage( "DownloadPluginsMain not found — BuilderPluginDownloader failed to load." );
+		return false;
+	}
+
+	lua_newtable( L );
+	lua_pushstring( L, "download" );
+	lua_rawseti( L, -2, 1 );
+	lua_pushstring( L, platform );
+	lua_rawseti( L, -2, 2 );
+	lua_pushstring( L, buildSettingsPath.c_str() );
+	lua_rawseti( L, -2, 3 );
+	lua_pushstring( L, destinationDirectoryPath );
+	lua_rawseti( L, -2, 4 );
+
+	lua_pushnil( L );                           // user (not required for Solar2D free plugins)
+	lua_pushinteger( L, Rtt_BUILD_YEAR );
+	lua_pushinteger( L, Rtt_BUILD_REVISION );
+
+	bool success = false;
+	int callResult = lua_pcall( L, 4, 1, 0 );
+	if ( callResult == 0 )
+	{
+		if ( lua_isnumber( L, -1 ) )
+		{
+			success = ( lua_tointeger( L, -1 ) == 0 );
+		}
+		lua_pop( L, 1 );
+	}
+	else
+	{
+		const char *errorMsg = lua_tostring( L, -1 );
+		if ( errorMsg )
+		{
+			params->SetBuildMessage( errorMsg );
+		}
+		lua_pop( L, 1 );
+	}
+
+	return success;
+}
+
+#endif // Rtt_NO_GUI
 
 int
 PlatformAppPackager::OpenBuildSettings( const char * srcDir )

--- a/platform/shared/Rtt_PlatformAppPackager.h
+++ b/platform/shared/Rtt_PlatformAppPackager.h
@@ -256,6 +256,20 @@ class PlatformAppPackager
 		bool UnzipPlugins( AppPackagerParams *params, Runtime *runtime, const char *destinationDirectoryPath );
 #endif
 
+#if defined( Rtt_NO_GUI )
+		/**
+		 * Downloads and extracts project plugins in a headless (CoronaBuilder) context where no Runtime is available.
+		 * Uses BuilderPluginDownloader.lua + CoronaBuilderPluginCollector — the same infrastructure iOS/tvOS builds use.
+		 * All plugin files are extracted flat into destinationDirectoryPath (lua_51/ is merged to root automatically).
+		 * @param params Pointer to the build's package parameters. Cannot be null.
+		 * @param platform Plugin platform string, e.g. "win32" or "osx".
+		 * @param destinationDirectoryPath Directory where plugin files will be extracted. Created if it does not exist.
+		 * @return Returns true on success (including when the project has no plugins to download).
+		 *         Returns false on error; params->GetBuildMessage() will contain a reason.
+		 */
+		bool DownloadPluginsHeadless( AppPackagerParams *params, const char *platform, const char *destinationDirectoryPath );
+#endif
+
 		int OpenBuildSettings( const char * srcDir );
 		virtual void OnReadingBuildSettings( lua_State *L, int index );
         void ReadGlobalCustomBuildId();

--- a/platform/windows/Corona.Simulator/Rtt/Rtt_Win32AppPackager.cpp
+++ b/platform/windows/Corona.Simulator/Rtt/Rtt_Win32AppPackager.cpp
@@ -384,142 +384,186 @@ int Win32AppPackager::DoLocalBuild(const Win32AppPackager::BuildSettings& buildS
 	WinString binDirectoryPath;
 	binDirectoryPath.SetUTF8(buildSettings.BinDirectoryPath);
 
-#if !defined( Rtt_NO_GUI )
 	// Extract the project's plugins to the "bin" directory.
 	// This must be done before extracting the Win32 app template so that plugins can't overwrite Corona's DLLs.
-	auto runtimePointer = buildSettings.ParamsPointer->GetRuntime();
-	if (runtimePointer && runtimePointer->RequiresDownloadablePlugins())
+	//
+	// In GUI (Simulator) builds we use the running Runtime to unzip pre-downloaded plugins.
+	// In headless (CoronaBuilder) builds we use DownloadPluginsHeadless() which drives
+	// BuilderPluginDownloader.lua + CoronaBuilderPluginCollector — the same infrastructure iOS uses.
 	{
-		// Unzip the project's plugins to an intermediate directory.
 		WinString intermediatePluginDirectoryPath(buildSettings.IntermediateDirectoryPath);
 		intermediatePluginDirectoryPath.Append(L"\\..\\Plugins");
-		bool wasUnzipped = UnzipPlugins(
-				buildSettings.ParamsPointer, buildSettings.ParamsPointer->GetRuntime(),
+		bool hasPlugins = false;
+
+#if !defined( Rtt_NO_GUI )
+		auto runtimePointer = buildSettings.ParamsPointer->GetRuntime();
+		if (runtimePointer && runtimePointer->RequiresDownloadablePlugins())
+		{
+			bool wasUnzipped = UnzipPlugins(
+					buildSettings.ParamsPointer, runtimePointer,
+					intermediatePluginDirectoryPath.GetUTF8());
+			if (!wasUnzipped)
+			{
+				return 3;
+			}
+			hasPlugins = true;
+		}
+#else
+		// Headless path: download and extract plugins via BuilderPluginDownloader.lua.
+		// DownloadPluginsHeadless succeeds even when there are no plugins in build.settings;
+		// we detect whether anything was extracted by checking the directory afterwards.
+		bool wasDownloaded = DownloadPluginsHeadless(
+				buildSettings.ParamsPointer, "win32",
 				intermediatePluginDirectoryPath.GetUTF8());
-		if (!wasUnzipped)
+		if (!wasDownloaded)
 		{
 			return 3;
 		}
-
-		// Compile the Lua plugins to the intermediate directory.
-		// Note: Precompiled *.lu files are copied to the given directory by the below function.
-		Win32AppPackagerParams::CoreSettings pluginParamsSettings{};
-		pluginParamsSettings.AppName = buildSettings.ParamsPointer->GetAppName();
-		pluginParamsSettings.DestinationDirectoryPath = buildSettings.BinDirectoryPath;
-		pluginParamsSettings.SourceDirectoryPath = intermediatePluginDirectoryPath.GetUTF8();
-		pluginParamsSettings.VersionString = buildSettings.ParamsPointer->GetVersion();
-		Win32AppPackagerParams pluginParams(pluginParamsSettings);
-		bool wasCompiled = CompileScripts(&pluginParams, buildSettings.IntermediateDirectoryPath);
-		if (!wasCompiled)
+		// Consider plugins present if the intermediate directory was populated.
 		{
-			if (Rtt_StringIsEmpty(buildSettings.ParamsPointer->GetBuildMessage()))
+			WIN32_FIND_DATAW probeData{};
+			std::wstring probePattern(intermediatePluginDirectoryPath.GetUTF16());
+			probePattern.append(L"\\*.*");
+			auto probeHandle = ::FindFirstFileW(probePattern.c_str(), &probeData);
+			if (probeHandle != INVALID_HANDLE_VALUE)
 			{
-				buildSettings.ParamsPointer->SetBuildMessage("Failed to compile plugin Lua scripts.");
-			}
-			return 5;
-		}
-
-		// Copy the DLL plugins to the "bin" directory.
-		std::wstring pluginPatternMatch(intermediatePluginDirectoryPath.GetUTF16());
-		pluginPatternMatch.append(L"\\*.*");
-		WIN32_FIND_DATAW findData{};
-		auto searchHandle = ::FindFirstFileW(pluginPatternMatch.c_str(), &findData);
-		if (searchHandle != INVALID_HANDLE_VALUE)
-		{
-			do
-			{
-				BOOL wasMoved = false;
-
-				if (_wcsicmp(findData.cFileName, L"plugin") == 0)
+				// Skip '.' and '..' — if there is anything else the directory is non-empty.
+				do
 				{
-					// Handle Lua plugins which are in the "plugin" directory tree.  All we need are the assets as
-					// the code is incorporated into resource.car.  This is done by moving the entire "plugin" tree 
-					// and then deleting any .lua or .lu files in it
-
-					std::wstring utf16SourceFilePath(intermediatePluginDirectoryPath.GetUTF16());
-					utf16SourceFilePath.append(L"\\");
-					utf16SourceFilePath.append(findData.cFileName);
-					std::wstring utf16DestinationFilePath(binDirectoryPath.GetUTF16());
-					utf16DestinationFilePath.append(L"\\corona-plugins");
-					CreateDirectoryW(utf16DestinationFilePath.c_str(), NULL);  // create the \corona-plugins directory if needed
-					utf16DestinationFilePath.append(L"\\plugin");
-					wasMoved = ::MoveFileW(utf16SourceFilePath.c_str(), utf16DestinationFilePath.c_str());
-
-					// Remove .lua and .lu files, we just want the assets
-					std::wstring commandLine(L"cmd /c del /s /q \"");
-					commandLine.append(utf16DestinationFilePath.c_str());
-					commandLine.append(L"\\*.lua\"");
-					commandLine.append(L" \"");
-					commandLine.append(utf16DestinationFilePath.c_str());
-					commandLine.append(L"\\*.lu\"");
-
-					Interop::Ipc::CommandLine::RunUntilExit(commandLine.c_str());
-				}
-				else
-				{
-					// It's a native plugin file
-
-					// Determine if the next plugin file's extension should be copied to the "bin" directory.
-					// This excludes Lua files and other files that might have accidentally been zipped up with the plugin.
-					const wchar_t *kUtf16AllowedExtensions[] = { L".dll", L".exe", L".manifest", nullptr };
-					bool shouldCopy = false;
-					auto fileNameLength = wcslen(findData.cFileName);
-					for (int index = 0; kUtf16AllowedExtensions[index]; index++)
+					if (_wcsicmp(probeData.cFileName, L".") != 0 &&
+					    _wcsicmp(probeData.cFileName, L"..") != 0)
 					{
-						auto allowedExtensionLength = wcslen(kUtf16AllowedExtensions[index]);
-						if (fileNameLength >= allowedExtensionLength)
+						hasPlugins = true;
+						break;
+					}
+				} while (::FindNextFileW(probeHandle, &probeData));
+				::FindClose(probeHandle);
+			}
+		}
+#endif // ! Rtt_NO_GUI
+
+		if (hasPlugins)
+		{
+			// Compile the Lua plugins to the intermediate directory.
+			// Note: Precompiled *.lu files are copied to the given directory by the below function.
+			Win32AppPackagerParams::CoreSettings pluginParamsSettings{};
+			pluginParamsSettings.AppName = buildSettings.ParamsPointer->GetAppName();
+			pluginParamsSettings.DestinationDirectoryPath = buildSettings.BinDirectoryPath;
+			pluginParamsSettings.SourceDirectoryPath = intermediatePluginDirectoryPath.GetUTF8();
+			pluginParamsSettings.VersionString = buildSettings.ParamsPointer->GetVersion();
+			Win32AppPackagerParams pluginParams(pluginParamsSettings);
+			bool wasCompiled = CompileScripts(&pluginParams, buildSettings.IntermediateDirectoryPath);
+			if (!wasCompiled)
+			{
+				if (Rtt_StringIsEmpty(buildSettings.ParamsPointer->GetBuildMessage()))
+				{
+					buildSettings.ParamsPointer->SetBuildMessage("Failed to compile plugin Lua scripts.");
+				}
+				return 5;
+			}
+
+			// Copy the DLL plugins to the "bin" directory.
+			std::wstring pluginPatternMatch(intermediatePluginDirectoryPath.GetUTF16());
+			pluginPatternMatch.append(L"\\*.*");
+			WIN32_FIND_DATAW findData{};
+			auto searchHandle = ::FindFirstFileW(pluginPatternMatch.c_str(), &findData);
+			if (searchHandle != INVALID_HANDLE_VALUE)
+			{
+				do
+				{
+					BOOL wasMoved = false;
+
+					if (_wcsicmp(findData.cFileName, L"plugin") == 0)
+					{
+						// Handle Lua plugins which are in the "plugin" directory tree.  All we need are the assets as
+						// the code is incorporated into resource.car.  This is done by moving the entire "plugin" tree
+						// and then deleting any .lua or .lu files in it
+
+						std::wstring utf16SourceFilePath(intermediatePluginDirectoryPath.GetUTF16());
+						utf16SourceFilePath.append(L"\\");
+						utf16SourceFilePath.append(findData.cFileName);
+						std::wstring utf16DestinationFilePath(binDirectoryPath.GetUTF16());
+						utf16DestinationFilePath.append(L"\\corona-plugins");
+						CreateDirectoryW(utf16DestinationFilePath.c_str(), NULL);  // create the \corona-plugins directory if needed
+						utf16DestinationFilePath.append(L"\\plugin");
+						wasMoved = ::MoveFileW(utf16SourceFilePath.c_str(), utf16DestinationFilePath.c_str());
+
+						// Remove .lua and .lu files, we just want the assets
+						std::wstring commandLine(L"cmd /c del /s /q \"");
+						commandLine.append(utf16DestinationFilePath.c_str());
+						commandLine.append(L"\\*.lua\"");
+						commandLine.append(L" \"");
+						commandLine.append(utf16DestinationFilePath.c_str());
+						commandLine.append(L"\\*.lu\"");
+
+						Interop::Ipc::CommandLine::RunUntilExit(commandLine.c_str());
+					}
+					else
+					{
+						// It's a native plugin file
+
+						// Determine if the next plugin file's extension should be copied to the "bin" directory.
+						// This excludes Lua files and other files that might have accidentally been zipped up with the plugin.
+						const wchar_t *kUtf16AllowedExtensions[] = { L".dll", L".exe", L".manifest", nullptr };
+						bool shouldCopy = false;
+						auto fileNameLength = wcslen(findData.cFileName);
+						for (int index = 0; kUtf16AllowedExtensions[index]; index++)
 						{
-							auto offset = fileNameLength - allowedExtensionLength;
-							if (_wcsicmp(findData.cFileName + offset, kUtf16AllowedExtensions[index]) == 0)
+							auto allowedExtensionLength = wcslen(kUtf16AllowedExtensions[index]);
+							if (fileNameLength >= allowedExtensionLength)
 							{
-								shouldCopy = true;
-								break;
+								auto offset = fileNameLength - allowedExtensionLength;
+								if (_wcsicmp(findData.cFileName + offset, kUtf16AllowedExtensions[index]) == 0)
+								{
+									shouldCopy = true;
+									break;
+								}
 							}
 						}
-					}
-					if (!shouldCopy)
-					{
-						continue;
-					}
-
-					// Copy the DLL plugin related file.
-					std::wstring utf16SourceFilePath(intermediatePluginDirectoryPath.GetUTF16());
-					utf16SourceFilePath.append(L"\\");
-					utf16SourceFilePath.append(findData.cFileName);
-					std::wstring utf16DestinationFilePath(binDirectoryPath.GetUTF16());
-					utf16DestinationFilePath.append(L"\\");
-					utf16DestinationFilePath.append(findData.cFileName);
-					wasMoved = ::MoveFileW(utf16SourceFilePath.c_str(), utf16DestinationFilePath.c_str());
-				}
-
-				if (!wasMoved)
-				{
-					std::string message("Failed to include plugin files.");
-					auto errorCode = ::GetLastError();
-					if (errorCode)
-					{
-						LPWSTR utf16Buffer = nullptr;
-						::FormatMessageW(
-							FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
-							nullptr, errorCode,
-							MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-							(LPWSTR)&utf16Buffer, 0, nullptr);
-						if (utf16Buffer)
+						if (!shouldCopy)
 						{
-							WinString stringConverter;
-							stringConverter.SetUTF16(utf16Buffer);
-							message.append("\r\n\r\nReason:\r\n   ");
-							message.append(stringConverter.GetUTF8());
-							::LocalFree(utf16Buffer);
+							continue;
 						}
+
+						// Copy the DLL plugin related file.
+						std::wstring utf16SourceFilePath(intermediatePluginDirectoryPath.GetUTF16());
+						utf16SourceFilePath.append(L"\\");
+						utf16SourceFilePath.append(findData.cFileName);
+						std::wstring utf16DestinationFilePath(binDirectoryPath.GetUTF16());
+						utf16DestinationFilePath.append(L"\\");
+						utf16DestinationFilePath.append(findData.cFileName);
+						wasMoved = ::MoveFileW(utf16SourceFilePath.c_str(), utf16DestinationFilePath.c_str());
 					}
-					buildSettings.ParamsPointer->SetBuildMessage(message.c_str());
-					return 3;
-				}
-			} while (::FindNextFileW(searchHandle, &findData));
+
+					if (!wasMoved)
+					{
+						std::string message("Failed to include plugin files.");
+						auto errorCode = ::GetLastError();
+						if (errorCode)
+						{
+							LPWSTR utf16Buffer = nullptr;
+							::FormatMessageW(
+								FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
+								nullptr, errorCode,
+								MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+								(LPWSTR)&utf16Buffer, 0, nullptr);
+							if (utf16Buffer)
+							{
+								WinString stringConverter;
+								stringConverter.SetUTF16(utf16Buffer);
+								message.append("\r\n\r\nReason:\r\n   ");
+								message.append(stringConverter.GetUTF8());
+								::LocalFree(utf16Buffer);
+							}
+						}
+						buildSettings.ParamsPointer->SetBuildMessage(message.c_str());
+						return 3;
+					}
+				} while (::FindNextFileW(searchHandle, &findData));
+				::FindClose(searchHandle);
+			}
 		}
 	}
-#endif // ! Rtt_NO_GUI
 
 	// Unzip the Win32 app template to the "bin" directory.
 	// This app template contains the pre-compiled exe, libraries, widget assets, etc.

--- a/tools/CoronaBuilder/BuilderPluginDownloader.lua
+++ b/tools/CoronaBuilder/BuilderPluginDownloader.lua
@@ -458,6 +458,62 @@ function DownloadPluginsMain(args, user, buildYear, buildRevision)
 			config:write(simConfig)
 		end
 		config:close()
+	elseif platform == 'win32' or platform == 'osx' or platform == 'macos' then
+
+		local destDir = args[4]
+		if not destDir then
+			print("ERROR: no output directory specified for '" .. platform .. "' plugin files.")
+			return 1
+		end
+
+		-- Set up native plugin cache directory (same layout as iOS/tvOS)
+		local pluginsDest
+		if windows then
+			pluginsDest = os.getenv('APPDATA') .. '\\Corona Labs'
+			lfs.mkdir(pluginsDest)
+			pluginsDest = pluginsDest .. '\\Corona Simulator'
+			lfs.mkdir(pluginsDest)
+			pluginsDest = pluginsDest .. '\\NativePlugins\\'
+			lfs.mkdir(pluginsDest)
+			pluginsDest = pluginsDest .. platform .. '\\'
+			lfs.mkdir(pluginsDest)
+		else
+			pluginsDest = os.getenv('HOME') .. '/Library/Application Support/Corona'
+			lfs.mkdir(pluginsDest)
+			pluginsDest = pluginsDest .. '/Native Plugins/'
+			lfs.mkdir(pluginsDest)
+			pluginsDest = pluginsDest .. platform .. '/'
+			lfs.mkdir(pluginsDest)
+		end
+
+		lfs.mkdir(destDir)
+
+		-- Download plugin archives using CoronaBuilderPluginCollector.
+		-- extractLocation causes all archives to be extracted flat into destDir,
+		-- with any lua_51/ subdirectory merged into root automatically.
+		local pluginCollector = require "CoronaBuilderPluginCollector"
+		-- Pass only the revision number to the collector (e.g. 9999, not "2100.9999").
+		-- CoronaBuilderPluginCollector's Solar2D directory checker does:
+		--   entryBuildNumber <= tonumber(params.build)
+		-- where entryBuildNumber is the revision extracted from version strings like "2020.3627".
+		-- Passing the full "year.revision" float (~2101) would be less than revisions like
+		-- 3627, making all version lookups fail. The iOS path in getPluginDirectories() uses
+		-- the hardcoded string "9999" for the same reason.
+		local collectorParams = {
+			pluginPlatform = platform,
+			plugins = settings.plugins,
+			destinationDirectory = pluginsDest,
+			extractLocation = destDir,
+			build = tostring(buildRevision),
+			download = builder.download,
+			fetch = builder.fetch
+		}
+		local err = pluginCollector.collect(collectorParams)
+		if err then
+			print("ERROR collecting plugins for '" .. platform .. "': " .. tostring(err))
+			return 1
+		end
+
 	else
 		print("ERROR: unsupported platform '".. platform .."'.")
 		return 1

--- a/tools/CoronaBuilder/Rtt_AppPackagerAppleFactory.mm
+++ b/tools/CoronaBuilder/Rtt_AppPackagerAppleFactory.mm
@@ -181,7 +181,20 @@ AppPackagerFactory::CreatePackagerParamsApple(
 
 		case TargetDevice::kOSXPlatform:
 		{
-			S32 targetDevice = -1;		// TODO: add OSX/Windows devices
+			// Read macOS-specific optional fields from the Lua params table.
+			lua_getfield( L, index, "appSigningIdentity" );
+			const char *appSigningIdentity = lua_tostring( L, -1 );
+			lua_pop( L, 1 );
+
+			lua_getfield( L, index, "installerSigningIdentity" );
+			const char *installerSigningIdentity = lua_tostring( L, -1 );
+			lua_pop( L, 1 );
+
+			lua_getfield( L, index, "distributionMethod" );
+			const char *distributionMethod = lua_tostring( L, -1 );
+			lua_pop( L, 1 );
+
+			S32 targetDevice = -1;
 			OSXAppPackager packager( fServices );
 			bool isDistributionBuild = false;
 			NSString *identity = nil;
@@ -196,7 +209,14 @@ AppPackagerFactory::CreatePackagerParamsApple(
 				identity = [AppleSigningIdentityController signingIdentity:provisionFile commonName:&commonName];
 			}
 
-			result = new OSXAppPackagerParams(
+			// If no provision file, allow a direct signing identity string (e.g. for Developer ID builds).
+			if ( identity == nil && appSigningIdentity != NULL )
+			{
+				identity = [NSString stringWithUTF8String:appSigningIdentity];
+				isDistributionBuild = true;
+			}
+
+			OSXAppPackagerParams *osxResult = new OSXAppPackagerParams(
 											  appName,
 											  version,
 											  [identity UTF8String],
@@ -210,7 +230,14 @@ AppPackagerFactory::CreatePackagerParamsApple(
 											  customBuildId,
 											  NULL,
 											  appBundleId,
-											  isDistributionBuild );
+											  isDistributionBuild,
+											  appSigningIdentity,
+											  installerSigningIdentity );
+
+			if ( distributionMethod )
+				osxResult->SetDistributionMethod( distributionMethod );
+
+			result = osxResult;
 		}
 		break;
 

--- a/tools/CoronaBuilder/Rtt_CoronaBuilder.cpp
+++ b/tools/CoronaBuilder/Rtt_CoronaBuilder.cpp
@@ -48,6 +48,10 @@ const int ONE_WEEK_IN_SECONDS = (7 * ONE_DAY_IN_SECONDS);
 #include <sys/types.h>
 #endif
 
+#if defined(CORONABUILDER_OSX)
+#include "Rtt_OSXAppPackager.h"
+#endif
+
 // ----------------------------------------------------------------------------
 
 namespace Rtt
@@ -477,7 +481,39 @@ CoronaBuilder::Build( const BuildParams& params ) const
 
 			appParams->Print();
 			packager->ReadBuildSettings(appParams->GetSrcDir());
-			int code = packager->Build( appParams, tmpDir.GetString() );
+
+			int code = PlatformAppPackager::kBuildError;
+#if defined(CORONABUILDER_OSX)
+			if ( targetPlatform == TargetDevice::kOSXPlatform )
+			{
+				OSXAppPackager *osxPackager = static_cast<OSXAppPackager*>(packager);
+				OSXAppPackagerParams *osxParams = static_cast<OSXAppPackagerParams*>(appParams);
+				const char *method = osxParams->GetDistributionMethod();
+
+				if ( Rtt_StringCompareNoCase(method, "app-store") == 0 )
+				{
+					// Build the Mac App Store .pkg without uploading.
+					// Upload manually using Transporter or xcrun altool/notarytool.
+					code = osxPackager->PackageForAppStore( osxParams, false, "", "" );
+				}
+				else if ( Rtt_StringCompareNoCase(method, "developer-id") == 0 )
+				{
+					code = osxPackager->PackageForSelfDistribution( osxParams, false );
+				}
+				else if ( Rtt_StringCompareNoCase(method, "developer-id-dmg") == 0 )
+				{
+					code = osxPackager->PackageForSelfDistribution( osxParams, true );
+				}
+				else // "developer" or unset — standard signed/unsigned .app
+				{
+					code = packager->Build( appParams, tmpDir.GetString() );
+				}
+			}
+			else
+#endif // CORONABUILDER_OSX
+			{
+				code = packager->Build( appParams, tmpDir.GetString() );
+			}
 
 			if ( 0 == code )
 			{

--- a/tools/CoronaBuilder/docs/README.html
+++ b/tools/CoronaBuilder/docs/README.html
@@ -24,7 +24,7 @@
 <pre><code>/path/to/CoronaBuilder.app/Contents/MacOS/CoronaBuilder deauthorize email password</code></pre>
 <h3 id="building">Building</h3>
 <p>To build you must supply a file in Lua or JSON formats that contain the build arguments.</p>
-<p>Here's an example Lua file for iOS (fishies.ios.lua):</p>
+<p>Here&#39;s an example Lua file for iOS (<code>fishies.ios.lua</code>):</p>
 <pre><code>local params =
 {
     platform=&#39;iOS&#39;,
@@ -41,13 +41,13 @@
     --]]
 }
 return params</code></pre>
-<p>And here's an example of a Lua file for Android (fishies.android.lua):</p>
+<p>Here&#39;s an example for Android (<code>fishies.android.lua</code>):</p>
 <pre><code>local params =
 {
     platform=&#39;Android&#39;,
     appName=&#39;Fishies&#39;,
     appVersion=&#39;1.0&#39;,
-    dstPath=&#39;/Users/wluh/Desktop&#39;,
+    dstPath=&#39;/Users/JohnSmith/Desktop&#39;,
     sdkPath=&#39;/Developer&#39;,
     projectPath=&#39;/Applications/CoronaSDK/SampleCode/Graphics/Fishies&#39;,
     androidAppPackage=&#39;com.coronalabs.Fishies&#39;,
@@ -62,17 +62,75 @@ return params</code></pre>
     --]]
 }
 return params</code></pre>
-<p>Note that in both Lua file, the <code>params</code> table is returned at the end of the file.</p>
+<p>Here&#39;s an example for macOS (<code>fishies.macos.lua</code>):</p>
+<pre><code>local params =
+{
+    platform    = &#39;osx&#39;,
+    appName     = &#39;Fishies&#39;,
+    appVersion  = &#39;1.0&#39;,
+    dstPath     = &#39;/Users/JohnSmith/Desktop&#39;,
+    projectPath = &#39;/Applications/CoronaSDK/SampleCode/Graphics/Fishies&#39;,
+
+    -- Optional: Xcode developer tools path (defaults to xcode-select -p).
+    -- sdkPath = &#39;/Applications/Xcode.app/Contents/Developer&#39;,
+
+    -- Optional: override the build number.
+    -- customBuildId = &#39;12345&#39;,
+
+    -- Signing -- Option A: provision file (identity derived automatically).
+    -- certificatePath = &#39;/path/to/App.provisionprofile&#39;,
+
+    -- Signing -- Option B: direct identity strings for Developer ID builds.
+    -- appSigningIdentity       = &#39;Developer ID Application: Your Name (TEAMID)&#39;,
+    -- installerSigningIdentity = &#39;Developer ID Installer: Your Name (TEAMID)&#39;,
+
+    -- Distribution method (default: &#39;developer&#39;):
+    --   &#39;developer&#39;        standard unsigned/developer-signed .app
+    --   &#39;app-store&#39;        Mac App Store .pkg (upload manually via Transporter)
+    --   &#39;developer-id&#39;     Developer ID signed .pkg for direct distribution
+    --   &#39;developer-id-dmg&#39; Developer ID signed .dmg for direct distribution
+    -- distributionMethod = &#39;developer&#39;,
+}
+return params</code></pre>
+<p>Here&#39;s an example for Windows (<code>fishies.win32.lua</code>):</p>
+<pre><code>local params =
+{
+    platform    = &#39;win32&#39;,
+    appName     = &#39;Fishies&#39;,
+    appVersion  = &#39;1.0&#39;,
+    dstPath     = &#39;C:\\Users\\JohnSmith\\Desktop&#39;,
+    projectPath = &#39;C:\\CoronaSDK\\SampleCode\\Graphics\\Fishies&#39;,
+
+    -- Optional: name of the output .exe (defaults to appName + &#39;.exe&#39;).
+    -- exeFileName = &#39;Fishies.exe&#39;,
+
+    -- Optional: Windows VERSIONINFO resource fields embedded in the .exe.
+    -- companyName    = &#39;My Company&#39;,
+    -- copyright      = &#39;Copyright (C) 2024 My Company&#39;,
+    -- appDescription = &#39;A Solar2D application&#39;,
+    -- versionString  = &#39;1.0.0.0&#39;,
+
+    -- Optional: override the build number.
+    -- customBuildId = &#39;12345&#39;,
+}
+return params</code></pre>
+<p>Note that in all Lua files, the <code>params</code> table is returned at the end of the file.</p>
 <p>To kick off the build process using these Lua files, type the following:</p>
 <pre><code>/path/to/CoronaBuilder.app/Contents/MacOS/CoronaBuilder build --lua /path/to/fishies.ios.lua
 
-/path/to/CoronaBuilder.app/Contents/MacOS/CoronaBuilder build --lua /path/to/fishies.android.lua</code></pre>
+/path/to/CoronaBuilder.app/Contents/MacOS/CoronaBuilder build --lua /path/to/fishies.android.lua
+
+/path/to/CoronaBuilder.app/Contents/MacOS/CoronaBuilder build --lua /path/to/fishies.macos.lua
+
+/path/to/CoronaBuilder.app/Contents/MacOS/CoronaBuilder build --lua /path/to/fishies.win32.lua</code></pre>
 <h2 id="ssh-sessions">SSH Sessions</h2>
 <h3 id="ios">iOS</h3>
-<p>If you wish to build on iOS and invoke CoronaBuilder in a SSH session, you must unlock the keychain corresponding to the developer certificate. Otherwise your app will not get signed properly. Typically, this is <code>login.keychain</code></p>
-<p>In the SSH session, you can type the following:</p>
-<pre><code>security unlock-keychain -p userpassword /Users/[yourusername]/Library/Keychains/login.keychain. </code></pre>
+<p>If you wish to build for iOS and invoke CoronaBuilder in a SSH session, you must unlock the keychain corresponding to the developer certificate. Otherwise your app will not get signed properly. Typically, this is <code>login.keychain</code>:</p>
+<pre><code>security unlock-keychain -p userpassword /Users/[yourusername]/Library/Keychains/login.keychain</code></pre>
 <p>where <code>userpassword</code> is the password corresponding to the user <code>[yourusername]</code>.</p>
+<h3 id="macos">macOS</h3>
+<p>The same keychain unlock is required for signed macOS builds (<code>distributionMethod</code> other than <code>&#39;developer&#39;</code>):</p>
+<pre><code>security unlock-keychain -p userpassword /Users/[yourusername]/Library/Keychains/login.keychain</code></pre>
 <h2 id="daily-builds">Daily Builds</h2>
 <p>You can build against a specific daily build number by adding the corresponding custom build id string in the <code>build.settings</code> file. A list of custom build ids is available <a href="https://developer.coronalabs.com/downloads/daily-build-ids">here</a>.</p>
 <pre><code>settings =

--- a/tools/CoronaBuilder/docs/README.mdown
+++ b/tools/CoronaBuilder/docs/README.mdown
@@ -24,7 +24,7 @@ To activate, type the following:
 
 where `email` and `password` are associated with the Enterprise account subscription.
 
-This will activate a computer to use CoronaBuilder. Every account is allowed one computer. 
+This will activate a computer to use CoronaBuilder. Every account is allowed one computer.
 
 If you wish to activate CoronaBuilder on a different computer for the same account, you must first deactivate the original computer before activating on another one (or purchase additional subscriptions):
 
@@ -35,49 +35,105 @@ If you wish to activate CoronaBuilder on a different computer for the same accou
 
 To build you must supply a file in Lua or JSON formats that contain the build arguments.
 
-Here's an example Lua file for iOS (fishies.ios.lua):
+Here's an example Lua file for iOS (`fishies.ios.lua`):
 
 	local params =
 	{
-		platform='iOS',
-		appName='Fishies',
-		appVersion='1.0',
-		dstPath='/Users/JohnSmith/Desktop',
-		sdkPath='/Developer',
-		certificatePath='/path/to/Dev.mobileprovision',
-		projectPath='/Applications/CoronaSDK/SampleCode/Graphics/Fishies',
+	    platform='iOS',
+	    appName='Fishies',
+	    appVersion='1.0',
+	    dstPath='/Users/JohnSmith/Desktop',
+	    sdkPath='/Developer',
+	    certificatePath='/path/to/Dev.mobileprovision',
+	    projectPath='/Applications/CoronaSDK/SampleCode/Graphics/Fishies',
 
-		-- Following are optional:
-		--[[
-		platformVersion='iOS6.0', -- allows targeting iOS beta builds
-		--]]
+	    -- Following are optional:
+	    --[[
+	    platformVersion='iOS6.0', -- allows targeting iOS beta builds
+	    --]]
 	}
 	return params
 
-And here's an example of a Lua file for Android (fishies.android.lua):
+Here's an example for Android (`fishies.android.lua`):
 
 	local params =
 	{
-		platform='Android',
-		appName='Fishies',
-		appVersion='1.0',
-		dstPath='/Users/wluh/Desktop',
-		sdkPath='/Developer',
-		projectPath='/Applications/CoronaSDK/SampleCode/Graphics/Fishies',
-		androidAppPackage='com.coronalabs.Fishies',
-		
-		-- Following are optional:
-		--[[
-		certificatePath='/path/to/cert.keystore',
-		keystorePassword='',
-		keystoreAlias='',
-		keystoreAliasPassword='',
-		androidVersionCode=1,
-		--]]
+	    platform='Android',
+	    appName='Fishies',
+	    appVersion='1.0',
+	    dstPath='/Users/JohnSmith/Desktop',
+	    sdkPath='/Developer',
+	    projectPath='/Applications/CoronaSDK/SampleCode/Graphics/Fishies',
+	    androidAppPackage='com.coronalabs.Fishies',
+
+	    -- Following are optional:
+	    --[[
+	    certificatePath='/path/to/cert.keystore',
+	    keystorePassword='',
+	    keystoreAlias='',
+	    keystoreAliasPassword='',
+	    androidVersionCode=1,
+	    --]]
 	}
 	return params
 
-Note that in both Lua file, the `params` table is returned at the end of the file.
+Here's an example for macOS (`fishies.macos.lua`):
+
+	local params =
+	{
+	    platform    = 'osx',
+	    appName     = 'Fishies',
+	    appVersion  = '1.0',
+	    dstPath     = '/Users/JohnSmith/Desktop',
+	    projectPath = '/Applications/CoronaSDK/SampleCode/Graphics/Fishies',
+
+	    -- Optional: Xcode developer tools path (defaults to xcode-select -p).
+	    -- sdkPath = '/Applications/Xcode.app/Contents/Developer',
+
+	    -- Optional: override the build number.
+	    -- customBuildId = '12345',
+
+	    -- Signing — Option A: provision file (identity derived automatically).
+	    -- certificatePath = '/path/to/App.provisionprofile',
+
+	    -- Signing — Option B: direct identity strings for Developer ID builds.
+	    -- appSigningIdentity       = 'Developer ID Application: Your Name (TEAMID)',
+	    -- installerSigningIdentity = 'Developer ID Installer: Your Name (TEAMID)',
+
+	    -- Distribution method (default: 'developer'):
+	    --   'developer'        standard unsigned/developer-signed .app
+	    --   'app-store'        Mac App Store .pkg (upload manually via Transporter)
+	    --   'developer-id'     Developer ID signed .pkg for direct distribution
+	    --   'developer-id-dmg' Developer ID signed .dmg for direct distribution
+	    -- distributionMethod = 'developer',
+	}
+	return params
+
+Here's an example for Windows (`fishies.win32.lua`):
+
+	local params =
+	{
+	    platform    = 'win32',
+	    appName     = 'Fishies',
+	    appVersion  = '1.0',
+	    dstPath     = 'C:\\Users\\JohnSmith\\Desktop',
+	    projectPath = 'C:\\CoronaSDK\\SampleCode\\Graphics\\Fishies',
+
+	    -- Optional: name of the output .exe (defaults to appName + '.exe').
+	    -- exeFileName = 'Fishies.exe',
+
+	    -- Optional: Windows VERSIONINFO resource fields embedded in the .exe.
+	    -- companyName    = 'My Company',
+	    -- copyright      = 'Copyright (C) 2024 My Company',
+	    -- appDescription = 'A Solar2D application',
+	    -- versionString  = '1.0.0.0',
+
+	    -- Optional: override the build number.
+	    -- customBuildId = '12345',
+	}
+	return params
+
+Note that in all Lua files, the `params` table is returned at the end of the file.
 
 To kick off the build process using these Lua files, type the following:
 
@@ -85,19 +141,27 @@ To kick off the build process using these Lua files, type the following:
 
 	/path/to/CoronaBuilder.app/Contents/MacOS/CoronaBuilder build --lua /path/to/fishies.android.lua
 
+	/path/to/CoronaBuilder.app/Contents/MacOS/CoronaBuilder build --lua /path/to/fishies.macos.lua
+
+	/path/to/CoronaBuilder.app/Contents/MacOS/CoronaBuilder build --lua /path/to/fishies.win32.lua
+
 
 SSH Sessions
 ------------
 
 ### iOS ###
 
-If you wish to build on iOS and invoke CoronaBuilder in a SSH session, you must unlock the keychain corresponding to the developer certificate. Otherwise your app will not get signed properly. Typically, this is `login.keychain`
+If you wish to build for iOS and invoke CoronaBuilder in a SSH session, you must unlock the keychain corresponding to the developer certificate. Otherwise your app will not get signed properly. Typically, this is `login.keychain`:
 
-In the SSH session, you can type the following:
-
-	security unlock-keychain -p userpassword /Users/[yourusername]/Library/Keychains/login.keychain. 
+	security unlock-keychain -p userpassword /Users/[yourusername]/Library/Keychains/login.keychain
 
 where `userpassword` is the password corresponding to the user `[yourusername]`.
+
+### macOS ###
+
+The same keychain unlock is required for signed macOS builds (`distributionMethod` other than `'developer'`):
+
+	security unlock-keychain -p userpassword /Users/[yourusername]/Library/Keychains/login.keychain
 
 
 Daily Builds
@@ -107,12 +171,12 @@ You can build against a specific daily build number by adding the corresponding 
 
 	settings =
 	{
-		build =
-		{
-			-- Replace $CUSTOM_BUILD_ID with a build id from https://developer.coronalabs.com/downloads/daily-build-ids
-			-- For example, to get 2012.1076, use "4a7c9b5c0a38bf8dae750d1ec902c08f"
-			custom = "$CUSTOM_BUILD_ID",
-		}
+	    build =
+	    {
+	        -- Replace $CUSTOM_BUILD_ID with a build id from https://developer.coronalabs.com/downloads/daily-build-ids
+	        -- For example, to get 2012.1076, use "4a7c9b5c0a38bf8dae750d1ec902c08f"
+	        custom = "$CUSTOM_BUILD_ID",
+	    }
 	}
 
 

--- a/tools/CoronaBuilder/docs/fishies.macos.lua
+++ b/tools/CoronaBuilder/docs/fishies.macos.lua
@@ -1,0 +1,41 @@
+local params =
+{
+	platform    = 'osx',
+	appName     = 'Fishies',
+	appVersion  = '1.0',
+	dstPath     = '/Users/XXXX/Desktop',
+	projectPath = '/Applications/CoronaSDK/SampleCode/Graphics/Fishies',
+
+	-- Optional: Xcode developer tools path.
+	-- Defaults to the active Xcode installation (xcode-select -p).
+	-- sdkPath = '/Applications/Xcode.app/Contents/Developer',
+
+	-- Optional: override the build number embedded in the binary.
+	-- customBuildId = '12345',
+
+	-- ── Signing ────────────────────────────────────────────────────────────────
+	--
+	-- Option A — Provision file (same as iOS).
+	--   CoronaBuilder reads the signing identity from the profile automatically.
+	--   Use for Mac App Store distribution.
+	--
+	-- certificatePath = '/Users/XXXX/Library/MobileDevice/Provisioning Profiles/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX.provisionprofile',
+
+	-- Option B — Direct identity strings (for Developer ID / self-distribution).
+	--   Use the certificate name exactly as shown in Keychain Access.
+	--   Required when distributionMethod = 'developer-id' or 'developer-id-dmg'.
+	--
+	-- appSigningIdentity       = 'Developer ID Application: Your Name (TEAMID)',
+	-- installerSigningIdentity = 'Developer ID Installer: Your Name (TEAMID)',
+
+	-- ── Distribution method ────────────────────────────────────────────────────
+	--
+	-- 'developer'        — (default) standard .app, unsigned or developer-signed
+	-- 'app-store'        — Mac App Store .pkg (upload manually via Transporter)
+	-- 'developer-id'     — Developer ID signed .pkg for direct distribution
+	-- 'developer-id-dmg' — Developer ID signed .dmg for direct distribution
+	--
+	-- distributionMethod = 'developer',
+}
+
+return params

--- a/tools/CoronaBuilder/docs/fishies.win32.lua
+++ b/tools/CoronaBuilder/docs/fishies.win32.lua
@@ -1,0 +1,23 @@
+local params =
+{
+	platform    = 'win32',
+	appName     = 'Fishies',
+	appVersion  = '1.0',
+	dstPath     = 'C:\\Users\\XXXX\\Desktop',
+	projectPath = 'C:\\CoronaSDK\\SampleCode\\Graphics\\Fishies',
+
+	-- Optional: name of the output .exe file.
+	-- Defaults to appName + '.exe'.
+	-- exeFileName = 'Fishies.exe',
+
+	-- Optional: Windows VERSIONINFO resource fields embedded in the .exe.
+	-- companyName    = 'My Company',
+	-- copyright      = 'Copyright (C) 2024 My Company',
+	-- appDescription = 'A Solar2D sample application',
+	-- versionString  = '1.0.0.0',
+
+	-- Optional: override the build number embedded in the binary.
+	-- customBuildId = '12345',
+}
+
+return params


### PR DESCRIPTION
## 一句话

Port `coronalabs/corona@00b5ca86` "MacOS and Windows Plugin support (and builder support) (#902)" 到 `bgfx-solar2d`，目标修 Daily Build > macOS-Simulator baseline failure。

## 来源

- upstream: [coronalabs/corona#902](https://github.com/coronalabs/corona/pull/902) by @scottrules44
- upstream commit: `00b5ca86`
- ported via `git apply --3way`（disjoint history 不能 cherry-pick）

## 改动范围

12 files / +680 -176，全在 `Rtt_*AppPackager` + `CoronaBuilder/`，不动 librtt/Renderer，与 bgfx 工作零交集。

## 期望收益

最近 5+ Daily Build runs > macOS-Simulator FAIL，错误：
- `copyAndBuild.sh: pushd: simulator-extensions/welcomescreen: No such file or directory`
- `cp: platform/mac/lfs: No such file or directory`
- `cp: platform/mac/modules/luasocket: No such file or directory`
- 多条 `lu/socket.*` / `mime` / `ltn12` 缺失

#902 加了 +98 行到 `Rtt_PlatformAppPackager.cpp`，预期解决资源拷贝缺失。

## 验收

- [ ] bgfx Build Verification 全绿（6/6）
- [ ] Daily Build macOS-Simulator 从 FAIL → PASS
- [ ] 其他 Daily Build jobs 不退化