### PR TITLE
fix(macos-sim): restore welcomescreen submodule + harden copyAndBuild.sh (#45)

### DIFF
--- a/simulator-extensions/copyAndBuild.sh
+++ b/simulator-extensions/copyAndBuild.sh
@@ -2,6 +2,7 @@
 
 # $1 is the src folder
 
+set -euo pipefail
 shopt -s extglob
 
 if [ -z "$1" ] || [ -z "$2" ] || [ -z "$3" ]
@@ -34,7 +35,7 @@ dir=$(pwd)
 LUAC_DIR=$dir
 popd > /dev/null
 
-if [ "$CONFIGURATION" = "Debug" ]
+if [ "${CONFIGURATION:-}" = "Debug" ]
 then
 	OPTIONS=
 else


### PR DESCRIPTION
## Summary
- Restores `simulator-extensions/welcomescreen` from a broken self-pointing symlink (mode 120000, blob 388bf109) back to a normal submodule gitlink (mode 160000 at upstream SHA `9c02f00d`).
- Hardens `simulator-extensions/copyAndBuild.sh` with `set -euo pipefail` + `\${CONFIGURATION:-}` so a missing/broken source dir fails fast instead of silently overwriting `SRC_DIR` with the caller's pwd.

Fixes #45.

## Why this fix (and why not the brief's original hypothesis)
The codesign error
\`\`\`
.../Extensions/welcome/CoronaShell/build/Release/CoronaShell.app/Contents/Frameworks/CoronaCards.framework/CoronaCards: bundle format is ambiguous
\`\`\`
is a downstream symptom of two coupled bugs:

1. **The welcomescreen tree entry is corrupt.** Commit \`53c511fc\` ("bgfx: re-apply view state after bgfx::reset (P40 black-screen fix)") accidentally type-changed twelve submodule entries from gitlink (160000) to symlink (120000) — including \`simulator-extensions/welcomescreen\`. The symlink content is the absolute path to itself, so it never resolves; \`actions/checkout submodules:recursive\` cannot init it. Upstream \`coronalabs/corona\` has it as a normal gitlink at the same SHA, so the fix is to put ours back to match.

2. **\`copyAndBuild.sh\` swallowed the failure.** The Xcode "Building Simulator Extensions" phase calls
   \`copyAndBuild.sh "\$SIMEXT/welcomescreen" .../Extensions/welcome "\$BUILT_PRODUCTS_DIR"\`.
   The script's \`pushd "\$SRC_DIR"\` failed on the broken symlink, but with no \`set -e\` it kept going with \`SRC_DIR=\$(pwd)\` — the caller's cwd, which was \`platform/mac\`. The subsequent \`cp -r "\$SRC_DIR"/* "\$DST_DIR/"\` then copied the entire \`platform/mac\` tree (including \`CoronaShell/build/Release/CoronaShell.app\` and \`build/Release/CoronaCards.framework\`) into \`Corona Simulator.app/Contents/Extensions/welcome/\`. That nested-bundle structure is exactly what codesign reported as ambiguous.

The brief originally proposed stripping \`build/\` intermediates before codesign. That would have masked the symptom but left \`Extensions/welcome/\` empty (no welcomescreen lua/ttf/templates), so it's not the right fix. Restoring the submodule fixes the source of the bad copy at the root.

## Scope
- Touches only \`simulator-extensions/welcomescreen\` and \`simulator-extensions/copyAndBuild.sh\`.
- The other 11 submodules type-changed by \`53c511fc\` (\`external/Box2D\`, \`CryptoPP\`, \`MetalANGLE\`, \`bgfx\`, \`bimg\`, \`bx\`, \`freetype-2.9\`, \`live-libs\`, \`luafilesystem\`, \`luasocket\`, \`openal-soft\`) are intentionally left as-is for this PR. Their CI flows currently round-trip through prebuilt artifacts and are not directly causing breakage; we'll address them in a follow-up once this fix is verified green so we don't bundle a high-risk submodule sweep with a build hotfix.

## Test plan
- [x] \`git submodule update --init simulator-extensions/welcomescreen\` materializes a real directory and \`git submodule status\` reports \`9c02f00d\` (matching upstream master).
- [x] \`copyAndBuild.sh\` negative test — broken-symlink source path → exits 1 with no destination writes.
- [x] \`copyAndBuild.sh\` positive test — real welcomescreen → copies lua/ttf/templates as before.
- [ ] Daily Build > macOS-Simulator job: codesign passes and DMG is produced.
- [ ] bgfx Build Verification: 6/6 SUCCESS (no regression on iOS template / template-angle paths).