### PR TITLE
ci: tag-based release pipeline — BUILD/BUILD_NUMBER split + DMG notarization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,6 +373,32 @@ jobs:
         run: ./tools/GHAction/build_dmg.sh
         env:
           CERT_PASSWORD: ${{ secrets.CertPassword }}
+      - name: Notarize DMG
+        env:
+          NOTARY_API_KEY: ${{ secrets.NOTARY_API_KEY }}
+          NOTARY_KEY_ID: ${{ secrets.NOTARY_KEY_ID }}
+          NOTARY_ISSUER_ID: ${{ secrets.NOTARY_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "${NOTARY_KEY_ID:-}" ] || [ -z "${NOTARY_ISSUER_ID:-}" ] || [ -z "${NOTARY_API_KEY:-}" ]; then
+            echo "Notarization secrets not set — skipping (DMG will be signed but not notarized)."
+            exit 0
+          fi
+          DMG=$(ls ./output/Corona-*.dmg 2>/dev/null | head -1 || true)
+          if [ -z "$DMG" ]; then echo "No DMG found in ./output"; exit 1; fi
+          echo "Notarizing $DMG"
+          KEY_FILE=$(mktemp -t notary_key)
+          chmod 600 "$KEY_FILE"
+          printf '%s\n' "$NOTARY_API_KEY" > "$KEY_FILE"
+          xcrun notarytool submit "$DMG" \
+              --key "$KEY_FILE" \
+              --key-id "$NOTARY_KEY_ID" \
+              --issuer "$NOTARY_ISSUER_ID" \
+              --wait \
+              --timeout 30m
+          rm -f "$KEY_FILE"
+          xcrun stapler staple "$DMG"
+          spctl --assess --type install --verbose=4 "$DMG" || true
       - name: Upload macOS Daily build artifact
         uses: actions/upload-artifact@v4
         with:

--- a/tools/GHAction/build_dmg.sh
+++ b/tools/GHAction/build_dmg.sh
@@ -25,8 +25,16 @@ fi
 
 BUILD_NUMBER=${BUILD_NUMBER:-3575}
 YEAR=${YEAR:-2020}
+# DMG filename suffix must match the release job's rename target,
+# which uses the cosmetic ${BUILD} (full tag, e.g. "3729.bgfx.v2"),
+# not the numeric ${BUILD_NUMBER} (used only for version macros).
+BUILD=${BUILD:-$BUILD_NUMBER}
 
-if ! bin/mac/build_dmg.sh -d -b "$YEAR.$BUILD_NUMBER" -e "${WORKSPACE}/Native/CoronaNative.tar.gz" "${WORKSPACE}" "${WORKSPACE}/docs"
+NATIVE_FLAG=""
+if [ -f "${WORKSPACE}/Native/CoronaNative.tar.gz" ]; then
+    NATIVE_FLAG="-e ${WORKSPACE}/Native/CoronaNative.tar.gz"
+fi
+if ! bin/mac/build_dmg.sh -d -b "$YEAR.$BUILD" $NATIVE_FLAG "${WORKSPACE}" "${WORKSPACE}/docs"
 then
     BUILD_FAILED=YES
     echo "BUILD FAILED"

--- a/tools/GHAction/daily_env.sh
+++ b/tools/GHAction/daily_env.sh
@@ -4,14 +4,22 @@ set -e
 : "${YEAR:=$(date +"%Y")}"
 if [[ "$GITHUB_REF" == refs/tags/* ]]
 then
-    : "${BUILD_NUMBER:=${GITHUB_REF#refs/tags/}}"
+    TAG_NAME="${GITHUB_REF#refs/tags/}"
+    : "${BUILD:=$TAG_NAME}"
+    # BUILD_NUMBER must be numeric only — it's substituted into Rtt_BUILD_REVISION
+    # (integer macro), CFBundleVersion, and Windows file version. Tags like
+    # "3729.bgfx.v2" must contribute only the leading "3729" to BUILD_NUMBER,
+    # while BUILD keeps the full tag string for release names / artifact filenames.
+    BUILD_NUMBER_FROM_TAG="$(printf '%s' "$TAG_NAME" | grep -oE '^[0-9]+' || true)"
+    : "${BUILD_NUMBER:=${BUILD_NUMBER_FROM_TAG:-$GITHUB_RUN_NUMBER}}"
 else
+    : "${BUILD:=$GITHUB_RUN_NUMBER}"
     : "${BUILD_NUMBER:=$GITHUB_RUN_NUMBER}"
 fi
 
 {
     echo "BUILD_NUMBER=$BUILD_NUMBER"
-    echo "BUILD=$BUILD_NUMBER"
+    echo "BUILD=$BUILD"
     echo "YEAR=$YEAR"
     echo "MONTH=$(date +"%-m")"
     echo "DAY=$(date +"%-d")"


### PR DESCRIPTION
## Summary

- **Split `BUILD` vs `BUILD_NUMBER`** in `daily_env.sh`: `BUILD` = full tag string (cosmetic, for artifact filenames / release name); `BUILD_NUMBER` = numeric prefix only (for `Rtt_BUILD_REVISION` integer macro, CFBundleVersion, Windows file version). Tags like `3729.bgfx.v2` no longer crash Xcode 26.3 native build.
- **Fix DMG filename** in `build_dmg.sh`: `-b "$YEAR.$BUILD"` (was `"$YEAR.$BUILD_NUMBER"`), so the produced DMG matches the release rename step.
- **Add DMG notarization step** in `build.yml`: `xcrun notarytool submit --wait` + `xcrun stapler staple`. Step is a no-op if secrets are missing (safe for forks). Requires 3 repo secrets: `NOTARY_API_KEY` (.p8), `NOTARY_KEY_ID`, `NOTARY_ISSUER_ID`.

## Verified on bgfx-solar2d

CI run [25531537485](https://github.com/labolado/corona/actions/runs/25531537485): all jobs PASS, notarize step `status: Accepted` (~3m20s). Local `spctl --assess → source=Notarized Developer ID` + `xcrun stapler validate → The validate action worked!`

## Test plan

- [ ] Trigger a tag-based Daily Build with a letter-suffix tag (e.g. `3730.v1`) — native build should not fail
- [ ] Verify produced DMG filename matches release rename target
- [ ] Verify notarization step completes successfully (requires secrets configured)