### PR TITLE
feat(ftl): add Firebase Test Lab Game Loop detection for iOS

### DIFF
--- a/platform/iphone/AppDelegate.mm
+++ b/platform/iphone/AppDelegate.mm
@@ -597,6 +597,17 @@ SetLaunchArgs( UIApplication *application, NSDictionary *launchOptions, Rtt::Run
 			lua_setfield( L, -2, "url" );
 		}
 
+		// Firebase Test Lab Game Loop detection
+		// FTL sends: -com.google.games.test.loops <scenario>
+		NSArray *args = [[NSProcessInfo processInfo] arguments];
+		NSUInteger idx = [args indexOfObject:@"-com.google.games.test.loops"];
+		if ( idx != NSNotFound && idx + 1 < [args count] )
+		{
+			NSString *scenario = [args objectAtIndex:idx + 1];
+			lua_pushstring( L, [scenario UTF8String] );
+			lua_setfield( L, -2, "gameLoopScenario" );
+		}
+
 		lua_pop( L, 1 );
 	}
 }


### PR DESCRIPTION
## Summary
- Add Firebase Test Lab Game Loop detection in AppDelegate.mm
- Extracts `-com.google.games.test.loops <scenario>` CLI arg into Lua `gameLoopScenario`
- Enables FTL Game Loop testing for iOS